### PR TITLE
fix(docs): update stale rlm-gap-fill references to rlm-distill across README, diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,18 @@ Sub-systems allowing fresh, isolated model context spaces for advanced tasks (au
 - **RLM Factory** — Reverse Language Modeling engine generating high-speed offline functional cache representations of code.
   ↳ [`ollama-launch`](plugins/rlm-factory/skills/ollama-launch/SKILL.md)
   ↳ [`rlm-curator`](plugins/rlm-factory/skills/rlm-curator/SKILL.md)
-  ↳ [`rlm-distill`](plugins/rlm-factory/skills/rlm-distill/SKILL.md)
-  ↳ [`rlm-factory-rlm-gap-fill`](plugins/rlm-factory/skills/rlm-factory-rlm-gap-fill/SKILL.md)
+  ↳ [`rlm-distill`](plugins/rlm-factory/agents/rlm-distill.md) *(agent)*
+  ↳ [`rlm-cleanup`](plugins/rlm-factory/agents/rlm-cleanup.md) *(agent)*
   ↳ [`rlm-init`](plugins/rlm-factory/skills/rlm-init/SKILL.md)
   ↳ [`tool-inventory-init`](plugins/rlm-factory/skills/tool-inventory-init/SKILL.md)
 - **Tool Inventory** — Vector-search registry for all python scripts making them accessible to agents without hard-coded rules.
   ↳ [`tool-inventory`](plugins/tool-inventory/skills/tool-inventory/SKILL.md)
 - **Vector DB** — ChromaDB driven continuous semantic embedding indexing module for native codebase integration search.
-  ↳ [`vector-db-agent`](plugins/vector-db/skills/vector-db-agent/SKILL.md)
-  ↳ [`vector-db-cleanup`](plugins/vector-db/skills/vector-db-cleanup/SKILL.md)
-  ↳ [`vector-db-ingest`](plugins/vector-db/skills/vector-db-ingest/SKILL.md)
+  ↳ [`vector-db-search`](plugins/vector-db/skills/vector-db-agent/SKILL.md) *(read-only skill)*
+  ↳ [`vdb-ingest`](plugins/vector-db/agents/vdb-ingest.md) *(agent)*
+  ↳ [`vdb-cleanup`](plugins/vector-db/agents/vdb-cleanup.md) *(agent)*
   ↳ [`vector-db-init`](plugins/vector-db/skills/vector-db-init/SKILL.md)
   ↳ [`vector-db-launch`](plugins/vector-db/skills/vector-db-launch/SKILL.md)
-  ↳ [`vector-db-query`](plugins/vector-db/skills/vector-db-query/SKILL.md)
 
 ### Utilities
 - **Migration Utils** — Standard scripts utilized during extensive codebase restructuring architectures.

--- a/plugins/rlm-factory/README.md
+++ b/plugins/rlm-factory/README.md
@@ -103,8 +103,8 @@ Store your customized LLM summarization prompts here.
 
 | Command | Script | Ollama? | Description |
 |:---|:---|:---|:---|
-| `/rlm-factory:distill` | `rlm-curator/scripts/distiller.py` | Yes | LLM-powered file summarization |
-| `/rlm-factory:gap-fill` | Sub-Agent (inject_summary.py) | No | Agent-powered summarization |
+| `/rlm-factory:distill` | `rlm-curator/scripts/distiller.py` | Yes | Ollama batch summarization |
+| `/rlm-factory:distill-agent` | `inject_summary.py` via agent | No | Agent-powered summarization |
 | `/rlm-factory:query` | `rlm-search/scripts/query_cache.py` | No | Search the semantic ledger |
 | `/rlm-factory:audit` | `rlm-curator/scripts/inventory.py` | No | Coverage report (fs vs cache) |
 | `/rlm-factory:cleanup` | `rlm-curator/scripts/cleanup_cache.py` | No | Remove stale/orphan entries |
@@ -115,7 +115,7 @@ For small batches (< 10 files), the agent can distill directly without Ollama by
 reading the file and writing the summary into the cache JSON. This is 3-5x faster
 and produces higher-quality summaries using frontier model intelligence.
 
-See `agents/rlm-gap-fill.md` for the full Agent Distill protocol.
+See `agents/rlm-distill.md` for the full Agent Distill protocol.
 
 ---
 
@@ -155,7 +155,7 @@ rlm-factory/
 |   +-- plugin.json              # Plugin identity + runtime deps
 +-- commands/
 |   +-- distill.md               # /rlm-factory:distill
-|   +-- rlm-factory_gap-fill.md  # /rlm-factory:gap-fill
+|   +-- distill-agent.md         # /rlm-factory:distill-agent
 |   +-- query.md                 # /rlm-factory:query
 |   +-- audit.md                 # /rlm-factory:audit
 |   +-- cleanup.md               # /rlm-factory:cleanup
@@ -172,7 +172,8 @@ rlm-factory/
 |   +-- ollama-launch/
 |       +-- SKILL.md             # Ollama server management
 +-- agents/
-|   +-- rlm-gap-fill.md          # Gap-Fill Sub-Agent configuration
+|   +-- rlm-distill.md           # rlm-distill agent (agent-first distillation)
+|   +-- rlm-cleanup.md          # rlm-cleanup agent (prune stale entries)
 +-- resources/
 |   +-- manifest-index.json      # Profile registry
 |   +-- distiller_manifest.json  # Default scope config

--- a/plugins/rlm-factory/references/diagrams/logic.mmd
+++ b/plugins/rlm-factory/references/diagrams/logic.mmd
@@ -15,7 +15,7 @@ flowchart TD
         Distiller -- "POST /api/generate + rlm_summarize_general.md prompt" --> Ollama((Ollama API\ngranite3.2:8b))
         Ollama -- "1-sentence dense summary" --> Distiller
         Distiller -- "Incremental write (fcntl.flock)" --> Cache[("rlm_summary_cache.json\nrlm_tool_cache.json")]
-        Inject["inject_summary.py\n(agent gap-fill path)"] -- "Single-file inject" --> Cache
+        Inject["inject_summary.py\n(agent distill path)"] -- "Single-file inject" --> Cache
     end
 
     subgraph Consumption ["Step 3: Query the Ledger (rlm-search skill)"]

--- a/plugins/rlm-factory/references/diagrams/workflow.mmd
+++ b/plugins/rlm-factory/references/diagrams/workflow.mmd
@@ -9,7 +9,7 @@ flowchart TD
     Audit --> CmdAudit[/"python plugins/rlm-factory/skills/rlm-curator/scripts/inventory.py --profile project"/]
     CmdAudit -- "Missing Files?" --> Gaps{Gaps Found?}
 
-    Gaps -- Yes --> Patch["Distill Specific File or\nUse Agent Gap-Fill (/rlm-factory_gap-fill)"]
+    Gaps -- Yes --> Patch["Distill Specific File or\nUse Agent Distill (/rlm-factory:distill-agent)"]
     Patch --> CmdPatch[/"python plugins/rlm-factory/skills/rlm-curator/scripts/inject_summary.py --profile project --file path"/]
     CmdPatch --> Cache
 

--- a/plugins/tool-inventory/README.md
+++ b/plugins/tool-inventory/README.md
@@ -86,7 +86,7 @@ ChromaDB is the primary truth store. JSON cache is kept for backward compatibili
 
 | RLM Command/Script | Purpose | Executable Type |
 |:---|:---|:---|
-| `/rlm-factory_gap-fill` | Agent-powered file summarization | ✅ Sub-Agent |
+| `/rlm-factory:distill-agent` | Agent-powered file summarization | Agent (inject_summary.py) |
 | `distiller.py` | Batch LLM summarization | ✅ Local Ollama |
 | `query_cache.py` | Legacy JSON cache search | ❌ Command Line |
 | `inventory.py` | Coverage reporting | ❌ Command Line |


### PR DESCRIPTION
## What Changed

Fixed all stale references to old renamed/removed agents and commands.

### Files Updated
- **Root README.md** -- rlm-factory skill list: removed `rlm-factory-rlm-gap-fill`, added `rlm-distill` (agent) + `rlm-cleanup` (agent); vector-db list: replaced `vector-db-agent/cleanup/ingest/query` skill links with `vector-db-search` (skill) + `vdb-ingest`/`vdb-cleanup` (agents)
- **plugins/rlm-factory/README.md** -- commands table: replaced `/rlm-factory:gap-fill` with `/rlm-factory:distill-agent`; agent section; directory structure
- **plugins/rlm-factory/references/diagrams/workflow.mmd** -- replaced `/rlm-factory_gap-fill` node label
- **plugins/rlm-factory/references/diagrams/logic.mmd** -- updated `agent gap-fill path` label to `agent distill path`
- **plugins/tool-inventory/README.md** -- RLM integration table: `/rlm-factory_gap-fill` -> `/rlm-factory:distill-agent`