### PR TITLE
docs: add npx skills install path; mark plugin-mapper/manager partially superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,35 @@ Instead of keeping documentation trapped in disparate folders, this site serves 
 
 ---
 
+## Installation
+
+Use the `npx skills` CLI to install plugins directly into your agent environment. It auto-detects installed agents (Claude Code, GitHub Copilot, Gemini, Cursor, and 30+ others) and wires everything up natively.
+
+```bash
+# Install all plugins from this repo
+npx skills add richfrem/agent-plugins-skills
+
+# Install a single plugin
+npx skills add richfrem/agent-plugins-skills/plugins/rlm-factory
+npx skills add richfrem/agent-plugins-skills/plugins/vector-db
+npx skills add richfrem/agent-plugins-skills/plugins/spec-kitty-plugin
+
+# Update all installed skills to latest
+npx skills update
+```
+
+> **Why this works**: each plugin in `plugins/` contains a `SKILL.md` following the [open agent skills standard](https://skills.sh/docs). The CLI reads it and configures your IDE automatically.
+
+Browse all available plugins and their install status at:
+**[skills.sh/richfrem/agent-plugins-skills](https://skills.sh/richfrem/agent-plugins-skills)**
+
+> [!NOTE]
+> **Contributors / local dev only**: if you are working on the plugins themselves, use `python plugins/plugin-mapper/skills/agent-bridge/scripts/install_all_plugins.py --target <your-agent>` to deploy from local source to your agent environments.
+
+
+
+---
+
 ## Core Architecture: Agent Loops
 
 The system relies heavily on the **[Agent Loops](plugins/agent-loops/README.md)** architecture, a sophisticated routing system that unifies state management across complex agent executions. 

--- a/plugins/plugin-manager/README.md
+++ b/plugins/plugin-manager/README.md
@@ -1,6 +1,13 @@
 # Plugin Manager
 
+> [!NOTE]
+> **Partially superseded by `npx skills`.**
+> - `/plugin-manager:update` and `/plugin-manager:cleanup` -- use `npx skills update` instead (auto-detects agents, no Python required).
+> - **`plugin-replicator`** remains the only tool for copying plugin source between local repos -- no npx equivalent exists for this workflow.
+> - `/plugin-manager:install` -- superseded by `npx skills add richfrem/agent-plugins-skills/plugins/<name>`.
+
 **The Orchestration Hub for Your Plugin Ecosystem**
+
 
 The **Plugin Manager** maintains a healthy local plugin ecosystem. It keeps agent configurations in sync with your `plugins/` folder and distributes plugins to other project repos.
 

--- a/plugins/plugin-mapper/README.md
+++ b/plugins/plugin-mapper/README.md
@@ -1,6 +1,12 @@
 # Plugin Mapper
 
+> [!NOTE]
+> **For consumers: use `npx skills` instead.**
+> `npx skills add richfrem/agent-plugins-skills` auto-detects your agent environment and installs all plugins natively -- no Python required.
+> This plugin is now primarily a **local development tool** for contributors who need to: deploy from local source, generate Gemini TOML, wire lifecycle hooks, or bridge to custom/unlisted targets.
+
 **The Universal Bridge for Agent Plugins**
+
 
 The **Plugin Mapper** adapts and bridges standard Claude Code plugins for use in many compatible agent environments — allowing you to write your core plugin logic once and deploy it across a wide variety of tools.
 


### PR DESCRIPTION
Adds npx skills as primary consumer install path + deprecation banners on plugin-mapper/manager. plugin-replicator explicitly NOT superseded.