### PR TITLE
feat: add runtime deprecation warnings for superseded scripts

### DIFF
--- a/plugins/plugin-manager/scripts/update_agent_system.py
+++ b/plugins/plugin-manager/scripts/update_agent_system.py
@@ -24,6 +24,12 @@ import sys
 import subprocess
 from pathlib import Path
 
+print("\n" + "="*80)
+print("⚠️  DEPRECATION NOTICE: This script is partially superseded by `npx skills`.")
+print("For standard syncing to agents, use: `npx skills update`")
+print("This script remains for legacy custom syncing and structural audits.")
+print("="*80 + "\n")
+
 ROOT = Path.cwd()
 
 SPEC_KITTY_SYNC = ROOT / "plugins/spec-kitty-plugin/skills/spec-kitty-agent/scripts/sync_configuration.py"

--- a/plugins/plugin-mapper/skills/agent-bridge/scripts/bridge_installer.py
+++ b/plugins/plugin-mapper/skills/agent-bridge/scripts/bridge_installer.py
@@ -48,6 +48,13 @@ import re
 import argparse
 from pathlib import Path
 
+print("\n" + "="*80)
+print("⚠️  DEPRECATION NOTICE: For consumers, this script is superseded by `npx skills`.")
+print("To install a plugin natively: `npx skills add richfrem/agent-plugins-skills/plugins/<name>`")
+print("This script is retained for contributors needing custom targets, ")
+print("Gemini TOML generation, or CLAUDE.md rule appending.")
+print("="*80 + "\n")
+
 try:
     import tomllib  # Python 3.11+
 except ImportError:

--- a/plugins/plugin-mapper/skills/agent-bridge/scripts/install_all_plugins.py
+++ b/plugins/plugin-mapper/skills/agent-bridge/scripts/install_all_plugins.py
@@ -38,6 +38,13 @@ import argparse
 import subprocess
 from pathlib import Path
 
+print("\n" + "="*80)
+print("⚠️  DEPRECATION NOTICE: For consumers, this script is superseded by `npx skills`.")
+print("To install all plugins natively, run from your project root:")
+print("  npx skills add richfrem/agent-plugins-skills")
+print("This local Python script is retained for contributors deploying from local source.")
+print("="*80 + "\n")
+
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent.parent.parent.parent.parent # Project root


### PR DESCRIPTION
Adds runtime print warnings to `update_agent_system.py`, `install_all_plugins.py`, and `bridge_installer.py` pointing consumers to `npx skills` while leaving the scripts functional for contributors.