### PR TITLE
fix: update plugin manifest script paths to new skill-local locations

### DIFF
--- a/plugins/agent-plugin-analyzer/.claude-plugin/plugin.json
+++ b/plugins/agent-plugin-analyzer/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
         "synthesize-learnings"
     ],
     "scripts": [
-        "scripts/inventory_plugin.py"
+        "skills/analyze-plugin/scripts/inventory_plugin.py"
     ],
     "dependencies": []
 }

--- a/plugins/agent-scaffolders/.claude-plugin/plugin.json
+++ b/plugins/agent-scaffolders/.claude-plugin/plugin.json
@@ -23,8 +23,13 @@
         "create-sub-agent"
     ],
     "scripts": [
-        "scripts/audit.py",
-        "scripts/scaffold.py"
+        "skills/audit-plugin/scripts/audit.py",
+        "skills/create-docker-skill/scripts/scaffold.py",
+        "skills/create-hook/scripts/scaffold.py",
+        "skills/create-plugin/scripts/scaffold.py",
+        "skills/create-skill/scripts/scaffold.py",
+        "skills/create-stateful-skill/scripts/scaffold.py",
+        "skills/create-sub-agent/scripts/scaffold.py"
     ],
     "dependencies": []
 }

--- a/plugins/env-helper/.claude-plugin/plugin.json
+++ b/plugins/env-helper/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
         "env-helper"
     ],
     "scripts": [
-        "scripts/env_helper.py"
+        "skills/env-helper/scripts/env_helper.py"
     ],
     "dependencies": []
 }

--- a/plugins/huggingface-utils/.claude-plugin/plugin.json
+++ b/plugins/huggingface-utils/.claude-plugin/plugin.json
@@ -12,7 +12,8 @@
         "hf-upload"
     ],
     "scripts": [
-        "scripts/hf_config.py"
+        "skills/hf-init/scripts/hf_config.py",
+        "skills/hf-upload/scripts/hf_config.py"
     ],
     "dependencies": []
 }


### PR DESCRIPTION
Fix missing tool scripts in npx installation. The previous refactor relocated scripts but forgot to update the plugin.json paths for 4 plugins.