### PR TITLE
fix(context-bundler): update plugin.json script paths to real physical file locations

### DIFF
--- a/plugins/context-bundler/.claude-plugin/plugin.json
+++ b/plugins/context-bundler/.claude-plugin/plugin.json
@@ -20,12 +20,10 @@
         "zip-bundling"
     ],
     "scripts": [
+        "scripts/manifest_manager.py",
+        "scripts/path_resolver.py",
         "skills/context-bundling/scripts/bundle.py",
-        "skills/context-bundling/scripts/manifest_manager.py",
-        "skills/context-bundling/scripts/path_resolver.py",
-        "skills/zip-bundling/scripts/bundle_zip.py",
-        "skills/zip-bundling/scripts/manifest_manager.py",
-        "skills/zip-bundling/scripts/path_resolver.py"
+        "skills/zip-bundling/scripts/bundle_zip.py"
     ],
     "dependencies": []
 }


### PR DESCRIPTION
The npx installer was failing on symlinked script paths in plugin.json. This fixes the script paths to point to the real physical files at the plugin root for shared scripts.