### PR TITLE
fix: update stale ../../references/ paths to skill-relative paths in SKILL.md files

### DIFF
--- a/plugins/rlm-factory/skills/rlm-init/SKILL.md
+++ b/plugins/rlm-factory/skills/rlm-init/SKILL.md
@@ -19,9 +19,9 @@ Real-world examples of each config file are in `references/examples/`:
 
 | File | Purpose |
 |:-----|:--------|
-| [`rlm_profiles.json`](../../references/examples/rlm_profiles.json) | Profile registry -- defines named caches and their manifest/cache paths |
-| [`rlm_summary_cache_manifest.json`](../../references/examples/rlm_summary_cache_manifest.json) | Project docs manifest -- what folders/globs to include and exclude |
-| [`rlm_tools_manifest.json`](../../references/examples/rlm_tools_manifest.json) | Tools manifest -- scoped to scripts and plugins only |
+| [`rlm_profiles.json`](references/examples/rlm_profiles.json) | Profile registry -- defines named caches and their manifest/cache paths |
+| [`rlm_summary_cache_manifest.json`](references/examples/rlm_summary_cache_manifest.json) | Project docs manifest -- what folders/globs to include and exclude |
+| [`rlm_tools_manifest.json`](references/examples/rlm_tools_manifest.json) | Tools manifest -- scoped to scripts and plugins only |
 
 ## Interactive Setup Protocol
 

--- a/plugins/vector-db/skills/vector-db-init/SKILL.md
+++ b/plugins/vector-db/skills/vector-db-init/SKILL.md
@@ -12,8 +12,8 @@ Real-world examples of each config file are in `references/examples/`:
 
 | File | Purpose |
 |:-----|:--------|
-| [`vector_profiles.json`](../../references/examples/vector_profiles.json) | Profile registry -- defines named vector collections and ChromaDB connection |
-| [`vector_knowledge_manifest.json`](../../references/examples/vector_knowledge_manifest.json) | Manifest -- what folders/globs to include/exclude in the vector index |
+| [`vector_profiles.json`](references/examples/vector_profiles.json) | Profile registry -- defines named vector collections and ChromaDB connection |
+| [`vector_knowledge_manifest.json`](references/examples/vector_knowledge_manifest.json) | Manifest -- what folders/globs to include/exclude in the vector index |
 
 ## When to Use This
 - When a user first installs the `vector-db` plugin.


### PR DESCRIPTION
Fixes rlm-factory/rlm-init and vector-db/vector-db-init SKILL.md which had ../../references/ paths. These now correctly reference references/ (the symlinked folder inside the skill).