### PR TITLE
fix(symlinks): correct symlink depth for resources and scripts subdirectories

### DIFF
--- a/plugins/agent-loops/skills/agent-swarm/resources/diagrams
+++ b/plugins/agent-loops/skills/agent-swarm/resources/diagrams
@@ -1,1 +1,1 @@
-../../resources/diagrams
+../../../resources/diagrams

--- a/plugins/agent-loops/skills/agent-swarm/resources/templates
+++ b/plugins/agent-loops/skills/agent-swarm/resources/templates
@@ -1,1 +1,1 @@
-../../resources/templates
+../../../resources/templates

--- a/plugins/agent-loops/skills/dual-loop/resources/diagrams
+++ b/plugins/agent-loops/skills/dual-loop/resources/diagrams
@@ -1,1 +1,1 @@
-../../resources/diagrams
+../../../resources/diagrams

--- a/plugins/agent-loops/skills/dual-loop/resources/templates
+++ b/plugins/agent-loops/skills/dual-loop/resources/templates
@@ -1,1 +1,1 @@
-../../resources/templates
+../../../resources/templates

--- a/plugins/agent-loops/skills/learning-loop/resources/diagrams
+++ b/plugins/agent-loops/skills/learning-loop/resources/diagrams
@@ -1,1 +1,1 @@
-../../resources/diagrams
+../../../resources/diagrams

--- a/plugins/agent-loops/skills/learning-loop/resources/templates
+++ b/plugins/agent-loops/skills/learning-loop/resources/templates
@@ -1,1 +1,1 @@
-../../resources/templates
+../../../resources/templates

--- a/plugins/agent-loops/skills/orchestrator/resources/diagrams
+++ b/plugins/agent-loops/skills/orchestrator/resources/diagrams
@@ -1,1 +1,1 @@
-../../resources/diagrams
+../../../resources/diagrams

--- a/plugins/agent-loops/skills/orchestrator/resources/templates
+++ b/plugins/agent-loops/skills/orchestrator/resources/templates
@@ -1,1 +1,1 @@
-../../resources/templates
+../../../resources/templates

--- a/plugins/agent-loops/skills/red-team-review/resources/diagrams
+++ b/plugins/agent-loops/skills/red-team-review/resources/diagrams
@@ -1,1 +1,1 @@
-../../resources/diagrams
+../../../resources/diagrams

--- a/plugins/agent-loops/skills/red-team-review/resources/templates
+++ b/plugins/agent-loops/skills/red-team-review/resources/templates
@@ -1,1 +1,1 @@
-../../resources/templates
+../../../resources/templates

--- a/plugins/huggingface-utils/skills/hf-init/scripts/hf_config.py
+++ b/plugins/huggingface-utils/skills/hf-init/scripts/hf_config.py
@@ -1,1 +1,1 @@
-../../scripts/hf_config.py
+../../../scripts/hf_config.py

--- a/plugins/huggingface-utils/skills/hf-upload/scripts/hf_config.py
+++ b/plugins/huggingface-utils/skills/hf-upload/scripts/hf_config.py
@@ -1,1 +1,1 @@
-../../scripts/hf_config.py
+../../../scripts/hf_config.py

--- a/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-bases-manager/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-canvas-architect/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-graph-traversal/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/obsidian-integration/skills/obsidian-init/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-init/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-init/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-init/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-init/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-init/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-markdown-mastery/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/architecture-background.md
+++ b/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/architecture-background.md
@@ -1,1 +1,1 @@
-../../resources/architecture-background.md
+../../../resources/architecture-background.md

--- a/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/kepano-analysis-summary.md
+++ b/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/kepano-analysis-summary.md
@@ -1,1 +1,1 @@
-../../resources/kepano-analysis-summary.md
+../../../resources/kepano-analysis-summary.md

--- a/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/safety-learnings.md
+++ b/plugins/obsidian-integration/skills/obsidian-vault-crud/resources/safety-learnings.md
@@ -1,1 +1,1 @@
-../../resources/safety-learnings.md
+../../../resources/safety-learnings.md

--- a/plugins/rlm-factory/skills/ollama-launch/resources/distiller_manifest.json
+++ b/plugins/rlm-factory/skills/ollama-launch/resources/distiller_manifest.json
@@ -1,1 +1,1 @@
-../../resources/distiller_manifest.json
+../../../resources/distiller_manifest.json

--- a/plugins/rlm-factory/skills/ollama-launch/resources/jobs
+++ b/plugins/rlm-factory/skills/ollama-launch/resources/jobs
@@ -1,1 +1,1 @@
-../../resources/jobs
+../../../resources/jobs

--- a/plugins/rlm-factory/skills/ollama-launch/resources/manifest-index.json
+++ b/plugins/rlm-factory/skills/ollama-launch/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/rlm-factory/skills/ollama-launch/resources/prompts
+++ b/plugins/rlm-factory/skills/ollama-launch/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/rlm-factory/skills/ollama-launch/resources/rlm_manifest.json
+++ b/plugins/rlm-factory/skills/ollama-launch/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/rlm-factory/skills/rlm-curator/resources/distiller_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-curator/resources/distiller_manifest.json
@@ -1,1 +1,1 @@
-../../resources/distiller_manifest.json
+../../../resources/distiller_manifest.json

--- a/plugins/rlm-factory/skills/rlm-curator/resources/jobs
+++ b/plugins/rlm-factory/skills/rlm-curator/resources/jobs
@@ -1,1 +1,1 @@
-../../resources/jobs
+../../../resources/jobs

--- a/plugins/rlm-factory/skills/rlm-curator/resources/manifest-index.json
+++ b/plugins/rlm-factory/skills/rlm-curator/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/rlm-factory/skills/rlm-curator/resources/prompts
+++ b/plugins/rlm-factory/skills/rlm-curator/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/rlm-factory/skills/rlm-curator/resources/rlm_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-curator/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/rlm-factory/skills/rlm-init/resources/distiller_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-init/resources/distiller_manifest.json
@@ -1,1 +1,1 @@
-../../resources/distiller_manifest.json
+../../../resources/distiller_manifest.json

--- a/plugins/rlm-factory/skills/rlm-init/resources/jobs
+++ b/plugins/rlm-factory/skills/rlm-init/resources/jobs
@@ -1,1 +1,1 @@
-../../resources/jobs
+../../../resources/jobs

--- a/plugins/rlm-factory/skills/rlm-init/resources/manifest-index.json
+++ b/plugins/rlm-factory/skills/rlm-init/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/rlm-factory/skills/rlm-init/resources/prompts
+++ b/plugins/rlm-factory/skills/rlm-init/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/rlm-factory/skills/rlm-init/resources/rlm_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-init/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/rlm-factory/skills/rlm-search/resources/distiller_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-search/resources/distiller_manifest.json
@@ -1,1 +1,1 @@
-../../resources/distiller_manifest.json
+../../../resources/distiller_manifest.json

--- a/plugins/rlm-factory/skills/rlm-search/resources/jobs
+++ b/plugins/rlm-factory/skills/rlm-search/resources/jobs
@@ -1,1 +1,1 @@
-../../resources/jobs
+../../../resources/jobs

--- a/plugins/rlm-factory/skills/rlm-search/resources/manifest-index.json
+++ b/plugins/rlm-factory/skills/rlm-search/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/rlm-factory/skills/rlm-search/resources/prompts
+++ b/plugins/rlm-factory/skills/rlm-search/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/rlm-factory/skills/rlm-search/resources/rlm_manifest.json
+++ b/plugins/rlm-factory/skills/rlm-search/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/tool-inventory/skills/tool-inventory-init/resources/RLM_TOOL_STRATEGY_ANALYSIS.md
+++ b/plugins/tool-inventory/skills/tool-inventory-init/resources/RLM_TOOL_STRATEGY_ANALYSIS.md
@@ -1,1 +1,1 @@
-../../resources/RLM_TOOL_STRATEGY_ANALYSIS.md
+../../../resources/RLM_TOOL_STRATEGY_ANALYSIS.md

--- a/plugins/tool-inventory/skills/tool-inventory-init/resources/manifest-index.json
+++ b/plugins/tool-inventory/skills/tool-inventory-init/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/tool-inventory/skills/tool-inventory-init/resources/prompts
+++ b/plugins/tool-inventory/skills/tool-inventory-init/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/tool-inventory/skills/tool-inventory-init/resources/rlm_manifest.json
+++ b/plugins/tool-inventory/skills/tool-inventory-init/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/tool-inventory/skills/tool-inventory/resources/RLM_TOOL_STRATEGY_ANALYSIS.md
+++ b/plugins/tool-inventory/skills/tool-inventory/resources/RLM_TOOL_STRATEGY_ANALYSIS.md
@@ -1,1 +1,1 @@
-../../resources/RLM_TOOL_STRATEGY_ANALYSIS.md
+../../../resources/RLM_TOOL_STRATEGY_ANALYSIS.md

--- a/plugins/tool-inventory/skills/tool-inventory/resources/manifest-index.json
+++ b/plugins/tool-inventory/skills/tool-inventory/resources/manifest-index.json
@@ -1,1 +1,1 @@
-../../resources/manifest-index.json
+../../../resources/manifest-index.json

--- a/plugins/tool-inventory/skills/tool-inventory/resources/prompts
+++ b/plugins/tool-inventory/skills/tool-inventory/resources/prompts
@@ -1,1 +1,1 @@
-../../resources/prompts
+../../../resources/prompts

--- a/plugins/tool-inventory/skills/tool-inventory/resources/rlm_manifest.json
+++ b/plugins/tool-inventory/skills/tool-inventory/resources/rlm_manifest.json
@@ -1,1 +1,1 @@
-../../resources/rlm_manifest.json
+../../../resources/rlm_manifest.json

--- a/plugins/vector-db/skills/vector-db-agent/resources/architecture_sequence.mmd
+++ b/plugins/vector-db/skills/vector-db-agent/resources/architecture_sequence.mmd
@@ -1,1 +1,1 @@
-../../resources/architecture_sequence.mmd
+../../../resources/architecture_sequence.mmd

--- a/plugins/vector-db/skills/vector-db-agent/resources/deployment_model.mmd
+++ b/plugins/vector-db/skills/vector-db-agent/resources/deployment_model.mmd
@@ -1,1 +1,1 @@
-../../resources/deployment_model.mmd
+../../../resources/deployment_model.mmd

--- a/plugins/vector-db/skills/vector-db-agent/resources/rag_design_choices.md
+++ b/plugins/vector-db/skills/vector-db-agent/resources/rag_design_choices.md
@@ -1,1 +1,1 @@
-../../resources/rag_design_choices.md
+../../../resources/rag_design_choices.md

--- a/plugins/vector-db/skills/vector-db-agent/resources/stabilizers
+++ b/plugins/vector-db/skills/vector-db-agent/resources/stabilizers
@@ -1,1 +1,1 @@
-../../resources/stabilizers
+../../../resources/stabilizers

--- a/plugins/vector-db/skills/vector-db-init/resources/architecture_sequence.mmd
+++ b/plugins/vector-db/skills/vector-db-init/resources/architecture_sequence.mmd
@@ -1,1 +1,1 @@
-../../resources/architecture_sequence.mmd
+../../../resources/architecture_sequence.mmd

--- a/plugins/vector-db/skills/vector-db-init/resources/deployment_model.mmd
+++ b/plugins/vector-db/skills/vector-db-init/resources/deployment_model.mmd
@@ -1,1 +1,1 @@
-../../resources/deployment_model.mmd
+../../../resources/deployment_model.mmd

--- a/plugins/vector-db/skills/vector-db-init/resources/rag_design_choices.md
+++ b/plugins/vector-db/skills/vector-db-init/resources/rag_design_choices.md
@@ -1,1 +1,1 @@
-../../resources/rag_design_choices.md
+../../../resources/rag_design_choices.md

--- a/plugins/vector-db/skills/vector-db-init/resources/stabilizers
+++ b/plugins/vector-db/skills/vector-db-init/resources/stabilizers
@@ -1,1 +1,1 @@
-../../resources/stabilizers
+../../../resources/stabilizers

--- a/plugins/vector-db/skills/vector-db-launch/resources/architecture_sequence.mmd
+++ b/plugins/vector-db/skills/vector-db-launch/resources/architecture_sequence.mmd
@@ -1,1 +1,1 @@
-../../resources/architecture_sequence.mmd
+../../../resources/architecture_sequence.mmd

--- a/plugins/vector-db/skills/vector-db-launch/resources/deployment_model.mmd
+++ b/plugins/vector-db/skills/vector-db-launch/resources/deployment_model.mmd
@@ -1,1 +1,1 @@
-../../resources/deployment_model.mmd
+../../../resources/deployment_model.mmd

--- a/plugins/vector-db/skills/vector-db-launch/resources/rag_design_choices.md
+++ b/plugins/vector-db/skills/vector-db-launch/resources/rag_design_choices.md
@@ -1,1 +1,1 @@
-../../resources/rag_design_choices.md
+../../../resources/rag_design_choices.md

--- a/plugins/vector-db/skills/vector-db-launch/resources/stabilizers
+++ b/plugins/vector-db/skills/vector-db-launch/resources/stabilizers
@@ -1,1 +1,1 @@
-../../resources/stabilizers
+../../../resources/stabilizers


### PR DESCRIPTION
Fixes the symlink generation for files inside resources/ and scripts/ subdirectories of skills. Previously used ../../ which resolved to the non-existent skills/resources/ directory. Now correctly uses ../../../ to reach the plugin root.