### PR TITLE
feat: audit and harden 4 plugins for marketplace standards compliance

### DIFF
--- a/plugins/agent-agentic-os/README.md
+++ b/plugins/agent-agentic-os/README.md
@@ -18,17 +18,35 @@ This plugin teaches agents how to:
 
 ## Installation
 
-### Option 1: Skills Only (End Users)
+### Option 1: From a Marketplace (Recommended)
+If this plugin is listed in a marketplace catalog, add the marketplace first then install:
 ```bash
-npx skills add ./plugins/agent-agentic-os
+/plugin marketplace add <marketplace-url>
+/plugin install agent-agentic-os
 ```
-This installs all skills from the Agentic OS plugin. Each skill can be used independently for OS management, memory operations, and evaluation tasks.
-
-### Option 2: Full Deployment (Skills + Commands + Agents)
-For complete access to all components (skills, commands, agents, hooks), use the bridge-plugin skill:
+For skills-only portability across all agents (Claude, Gemini, Copilot, etc.):
 ```bash
-# Use the bridge-plugin skill to deploy all components
-# python ./plugins/plugin-manager/scripts/bridge_installer.py --plugin plugins/agent-agentic-os
+npx skills add <marketplace-url>/plugins/agent-agentic-os
+```
+
+### Option 2: From GitHub Directly
+```bash
+# Skills only (portable, works with all agents)
+npx skills add richfrem/agent-plugins-skills --path plugins/agent-agentic-os
+
+# Full plugin (Claude Code native - skills + commands + agents + hooks)
+/plugin marketplace add richfrem/agent-plugins-skills
+/plugin install agent-agentic-os
+```
+
+### Option 3: Local Development Checkout
+```bash
+# Skills only
+npx skills add ./plugins/agent-agentic-os
+
+# Full plugin
+/plugin marketplace add ./
+/plugin install agent-agentic-os
 ```
 
 **Note:** This plugin installs with **standard library only** (no external dependencies). See `requirements.txt` for details.

--- a/plugins/agent-agentic-os/skills/agentic-os-guide/SKILL.md
+++ b/plugins/agent-agentic-os/skills/agentic-os-guide/SKILL.md
@@ -32,7 +32,6 @@ description: >
   Question about a specific file -- read it directly, do not invoke the full guide.
   </commentary>
   </example>
-disable-model-invocation: false
 allowed-tools: Read, Write
 ---
 

--- a/plugins/agent-agentic-os/skills/agentic-os-init/SKILL.md
+++ b/plugins/agent-agentic-os/skills/agentic-os-init/SKILL.md
@@ -33,7 +33,6 @@ description: >
   Question about file placement triggers the init skill even without a full setup request.
   </commentary>
   </example>
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-agentic-os/skills/os-clean-locks/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-clean-locks/SKILL.md
@@ -22,10 +22,7 @@ description: >
   Implicit audit trigger -- agent detects deadlock from kernel output and self-heals using os-clean-locks without user prompting.
   </commentary>
   </example>
-model: inherit
-color: red
-tools: ["Bash", "Read", "Write"]
-skills: []
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies
@@ -69,7 +66,7 @@ If kernel.py does not exist, skip this step.
 
 ### Phase 3: Lock Removal
 1. For each `.lock` file found, safely delete it using the `Bash` tool (e.g., `rm context/.locks/skill.lock`).
-2. **Update OS State**: Run `python3 context/kernel.py state_update active_agent os-clean-locks` and `python3 context/kernel.py state_update locks_cleared true`.
+2. **Update OS State** (if kernel.py is available): Run `python3 context/kernel.py state_update active_agent os-clean-locks` and `python3 context/kernel.py state_update locks_cleared true`. Skip this step if `context/kernel.py` does not exist.
 
 ### Phase 4: Final Briefing
 

--- a/plugins/agent-agentic-os/skills/session-memory-manager/SKILL.md
+++ b/plugins/agent-agentic-os/skills/session-memory-manager/SKILL.md
@@ -34,8 +34,18 @@ description: >
   </Read>
   <commentary>Reads documentation instead of trying to lock the memory manager.</commentary>
   </example>
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
+---
+
+## Prerequisites
+
+This skill requires the **Agentic OS to be initialized first**. It calls `context/kernel.py`, `context/memory.md`, and `context/.locks/` — files that only exist after running the `agentic-os-init` skill in your project.
+
+If you have not yet initialized the OS, run:
+```
+agentic-os-init
+```
+
 ---
 
 ## Dependencies

--- a/plugins/agent-agentic-os/skills/skill-improvement-eval/SKILL.md
+++ b/plugins/agent-agentic-os/skills/skill-improvement-eval/SKILL.md
@@ -33,10 +33,7 @@ description: >
   Information request, not an evaluation trigger. Do not trigger skill-improvement-eval.
   </commentary>
   </example>
-model: inherit
-color: yellow
-tools: ["Bash", "Read", "Write"]
-skills: []
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies

--- a/plugins/agent-plugin-analyzer/.claude-plugin/plugin.json
+++ b/plugins/agent-plugin-analyzer/.claude-plugin/plugin.json
@@ -6,5 +6,12 @@
         "name": "Richard Fremmerlid"
     },
     "repository": "https://github.com/richfrem/agent-plugins-skills",
-    "license": "MIT"
+    "license": "MIT",
+    "keywords": [
+        "plugin-analyzer",
+        "pattern-extraction",
+        "security-audit",
+        "maturity-model",
+        "skill-analysis"
+    ]
 }

--- a/plugins/agent-plugin-analyzer/README.md
+++ b/plugins/agent-plugin-analyzer/README.md
@@ -3,17 +3,30 @@
 A meta-plugin that gives agents the ability to systematically analyze plugin and skill collections, extract design patterns, detect security risks, score maturity, and generate actionable improvement recommendations — powering a virtuous cycle of continuous learning.
 
 ## Installation
-### Option 1: Skills Only (End Users)
+
+### Option 1: From a Marketplace (Recommended)
+```bash
+/plugin marketplace add <marketplace-url>
+/plugin install agent-plugin-analyzer
+```
+For skills-only portability across all agents (Claude, Gemini, Copilot, etc.):
+```bash
+npx skills add <marketplace-url>/plugins/agent-plugin-analyzer
+```
+
+### Option 2: From GitHub Directly
+```bash
+# Skills only
+npx skills add richfrem/agent-plugins-skills --path plugins/agent-plugin-analyzer
+
+# Full plugin (Claude Code native)
+/plugin marketplace add richfrem/agent-plugins-skills
+/plugin install agent-plugin-analyzer
+```
+
+### Option 3: Local Development Checkout
 ```bash
 npx skills add ./plugins/agent-plugin-analyzer
-```
-This installs the skills from this plugin.
-
-### Option 2: Full Deployment (Skills + Commands + Agents)
-For complete access to all components, use the bridge-plugin skill:
-```bash
-# Use the bridge-plugin skill to deploy all components
-# python ./plugins/plugin-manager/scripts/bridge_installer.py --plugin plugins/agent-plugin-analyzer
 ```
 
 ## Purpose

--- a/plugins/agent-plugin-analyzer/skills/analyze-plugin/references/analysis-framework.md
+++ b/plugins/agent-plugin-analyzer/skills/analyze-plugin/references/analysis-framework.md
@@ -9,7 +9,7 @@ Deep reference for the 6-phase plugin/skill analysis methodology.
 The inventory phase produces a complete file manifest. The goal is zero surprises — every file accounted for and classified.
 
 **Classification Priority Order:**
-1. Exact filename match (e.g., `./SKILL.md` → skill, `plugin.json` → manifest)
+1. Exact filename match (e.g., `./SKILL.md` → skill, `.claude-plugin/plugin.json` → manifest)
 2. Parent directory context (e.g., files in `commands/` → command, files in `references/` → reference)
 3. File extension fallback (e.g., `.py` → script, `.md` → document)
 4. Default to "other"

--- a/plugins/agent-plugin-analyzer/skills/audit-plugin-l5/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/audit-plugin-l5/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-plugin-l5
 description: Triggers the L5 Red Team Sub-Agent to rigorously audit a plugin against the 39-point L4 pattern matrix.
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-plugin-analyzer/skills/audit-plugin/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/audit-plugin/SKILL.md
@@ -2,13 +2,12 @@
 name: audit-plugin
 description: >
   This skill should be used when the user asks to "audit a plugin", "validate my plugin",
-  "check plugin structure", "verify plugin is correct", "validate ././././././././././././plugin.json", "check if
+  "check plugin structure", "verify plugin is correct", "validate .claude-plugin/plugin.json", "check if
   my plugin is compliant", "review plugin components", or mentions plugin validation or
   structure compliance. Also trigger proactively after the user creates or modifies any
-  plugin component (commands, agents, skills, hooks, ././././././././././././plugin.json). Use this skill even
+  plugin component (commands, agents, skills, hooks, .claude-plugin/plugin.json). Use this skill even
   when the user says "check my work" or "make sure this is right" in a plugin context.
   Do NOT use this for auditing individual skills only (use skill-reviewer for that).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Glob, Grep
 ---
 
@@ -123,13 +122,13 @@ For issues the scripts may not catch:
 **Plugin structure check:**
 ```bash
 # Manifest must be here (not in root)
-ls ./././././././././././././plugin.json
+ls .claude-plugin/plugin.json
 
 # Components must be at root (not in .claude-plugin/)
 ls commands/ agents/ skills/ hooks/
 
 # Validate JSON
-jq . ./././././././././././././plugin.json
+jq . .claude-plugin/plugin.json
 ```
 
 **Security scan:**
@@ -177,12 +176,12 @@ grep -rn "/Users/\|/home/" --include="*.json" --include="*.sh" .
 
 ## Standards Reference
 
-**././././././././././././plugin.json minimal valid:**
+**.claude-plugin/plugin.json minimal valid:**
 ```json
 { "name": "plugin-name" }
 ```
 
-**././././././././././././plugin.json recommended:**
+**.claude-plugin/plugin.json recommended:**
 ```json
 {
   "name": "plugin-name",

--- a/plugins/agent-plugin-analyzer/skills/mine-plugins/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/mine-plugins/SKILL.md
@@ -1,6 +1,14 @@
 ---
+name: mine-plugins
+description: >
+  Trigger with "mine plugins", "analyze plugin collection", "run the full analysis pipeline",
+  "inventory and analyze all plugins", "mine patterns from this directory", or when you want
+  to run the complete virtuous cycle: inventory, analyze, extract patterns, synthesize
+  recommendations, and deliver a structured report. Use this even if the user just says
+  "analyze everything in this folder".
 user-invocable: true
 argument-hint: "[path-to-plugin-or-directory]"
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies
@@ -53,7 +61,7 @@ Run the full analysis pipeline on a plugin or collection of plugins. This is the
 ### Step 1: Determine Scope
 
 Check if `$ARGUMENTS` points to:
-- A **single plugin** (contains `./plugin.json` or `skills/` directory) → Single Plugin Mode
+- A **single plugin** (contains `.claude-plugin/plugin.json` or `skills/` directory) → Single Plugin Mode
 - A **directory of plugins** (contains multiple subdirectories with plugins) → Comparative Mode
 - A **single skill** (contains `SKILL.md`) → Single Skill Mode
 

--- a/plugins/agent-plugin-analyzer/skills/mine-skill/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/mine-skill/SKILL.md
@@ -1,6 +1,13 @@
 ---
+name: mine-skill
+description: >
+  Trigger with "mine this skill", "analyze this skill", "run targeted skill analysis",
+  "extract patterns from this skill", or when you want focused analysis on a single Agent
+  Skill directory without processing an entire plugin. Use this when the user points to
+  a specific skill folder or says "look at this skill".
 user-invocable: true
 argument-hint: "[path-to-skill-directory]"
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies

--- a/plugins/agent-plugin-analyzer/skills/self-audit/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/self-audit/SKILL.md
@@ -1,6 +1,13 @@
 ---
+name: self-audit
+description: >
+  Trigger with "run self-audit", "test the analyzer", "regression test the plugin analyzer",
+  "audit the agent-plugin-analyzer", or "verify the analyzer works correctly". Runs the
+  analyze-plugin skill against the agent-plugin-analyzer itself and its test fixtures as a
+  regression smoke test. Use this after making changes to the analyzer to verify nothing broke.
 user-invocable: true
 argument-hint: "[optional: path to plugin]"
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies

--- a/plugins/agent-scaffolders/.claude-plugin/plugin.json
+++ b/plugins/agent-scaffolders/.claude-plugin/plugin.json
@@ -12,8 +12,5 @@
         "plugin-generator",
         "skill-generator",
         "agent-tooling"
-    ],
-    "agents": [],
-    "hooks": [],
-    "commands": []
+    ]
 }

--- a/plugins/agent-scaffolders/README.md
+++ b/plugins/agent-scaffolders/README.md
@@ -1,17 +1,30 @@
 # Agent Scaffolders Plugin
 
 ## Installation
-### Option 1: Skills Only (End Users)
+
+### Option 1: From a Marketplace (Recommended)
+```bash
+/plugin marketplace add <marketplace-url>
+/plugin install agent-scaffolders
+```
+For skills-only portability across all agents (Claude, Gemini, Copilot, etc.):
+```bash
+npx skills add <marketplace-url>/plugins/agent-scaffolders
+```
+
+### Option 2: From GitHub Directly
+```bash
+# Skills only
+npx skills add richfrem/agent-plugins-skills --path plugins/agent-scaffolders
+
+# Full plugin (Claude Code native)
+/plugin marketplace add richfrem/agent-plugins-skills
+/plugin install agent-scaffolders
+```
+
+### Option 3: Local Development Checkout
 ```bash
 npx skills add ./plugins/agent-scaffolders
-```
-This installs the skills from this plugin.
-
-### Option 2: Full Deployment (Skills + Commands + Agents)
-For complete access to all components, use the bridge-plugin skill:
-```bash
-# Use the bridge-plugin skill to deploy all components
-# python ./plugins/plugin-manager/scripts/bridge_installer.py --plugin plugins/agent-scaffolders
 ```
 
 ## Purpose

--- a/plugins/agent-scaffolders/skills/continuous-skill-optimizer/SKILL.md
+++ b/plugins/agent-scaffolders/skills/continuous-skill-optimizer/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: continuous-skill-optimizer
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Autonomous optimization loop for any skill. Trigger with "optimize this skill",
   "run the continuous optimizer", "improve this trigger description", or when you want
   to automatically test variations of a skill's instructions to find the most empirically
   effective prompt using the benchmarking engine.
-disable-model-invocation: false
+allowed-tools: Bash, Read, Write
 ---
 
 ## Dependencies

--- a/plugins/agent-scaffolders/skills/create-agentic-workflow/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-agentic-workflow/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-agentic-workflow
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Scaffold GitHub Agent files from an existing Agent Skill. Generates IDE/UI agents
   (invokable from Copilot Chat) or CI/CD autonomous agents. Trigger with "create a

--- a/plugins/agent-scaffolders/skills/create-azure-agent/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-azure-agent/SKILL.md
@@ -1,8 +1,5 @@
 ---
 name: create-azure-agent
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill---
-name: create-azure-agent
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Interactive initialization script that generates Azure AI Foundry Agent API deployment
   wrappers. Trigger with "deploy this skill to azure", "create an azure foundry agent",

--- a/plugins/agent-scaffolders/skills/create-command/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-command/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-command
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user asks to "create a slash command", "add a command",
   "write a custom command", "define a command with arguments", "create a command that runs
@@ -12,7 +11,6 @@ description: >
   that reviews PRs" or "automate my deploy workflow" should trigger this.
   Do NOT use this for hooks (use create-hook), skills (use create-skill), or agents
   (use create-sub-agent).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/create-command/references/examples/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-command/references/examples/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-command
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user asks to "create a slash command", "add a command",
   "write a custom command", "define a command with arguments", "create a command that runs
@@ -12,7 +11,6 @@ description: >
   that reviews PRs" or "automate my deploy workflow" should trigger this.
   Do NOT use this for hooks (use create-hook), skills (use create-skill), or agents
   (use create-sub-agent).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/create-docker-skill/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-docker-skill/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: create-docker-skill
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: Interactive initialization script that generates a compliant Agent Skill containing pre-flight environment checks, subprocess execution scaffolding, and a security-override config. Use when authoring new workflow routines that depend on external containerized runtimes (e.g., Docker, Nextflow, HPC).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/create-github-action/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-github-action/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-github-action
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Scaffold a traditional deterministic GitHub Actions CI/CD workflow. Trigger with 
   "setup github actions", "create a test workflow", "add a ci pipeline", "setup PR validation",

--- a/plugins/agent-scaffolders/skills/create-hook/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-hook/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-hook
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user asks to "create a hook", "add a hook",
   "add a PreToolUse hook", "add a Stop hook", "validate tool use", "implement a
@@ -11,7 +10,6 @@ description: >
   the user doesn't say the word "hook" explicitly -- e.g. "run a script before
   Claude writes files" or "validate commands before execution" should trigger this.
   Do NOT use this for creating skills (use create-skill) or sub-agents (use create-sub-agent).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/create-mcp-integration/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-mcp-integration/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-mcp-integration
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Interactive initialization script that scaffolds a new Model Context Protocol (MCP) server
   integration for a plugin. Trigger with "add an MCP", "setup mcp server", "integrate postgres mcp",

--- a/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-plugin
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user asks to "create a plugin", "scaffold a plugin",
   "build a new plugin", "set up plugin structure", "initialize a plugin", "make a Claude
@@ -10,7 +9,6 @@ description: >
   "I want to build something for Claude Code." Do NOT use this for creating individual
   components in isolation (use create-skill, create-command, create-hook, create-sub-agent,
   or create-mcp-integration for those).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 
@@ -54,6 +52,8 @@ plugin-name/
 ├── hooks/
 │   └── hooks.json           # Event handler configuration
 ├── .mcp.json                # MCP server definitions
+├── .lsp.json                # LSP server configurations
+├── settings.json            # Default settings (e.g., default agent)
 ├── scripts/                 # Shared utilities and helpers
 └── README.md
 ```
@@ -158,7 +158,8 @@ Only `name` is truly required. `name` must be kebab-case. Version follows semver
   "commands": "./custom-commands",
   "agents": ["./agents", "./specialized-agents"],
   "hooks": "./config/hooks.json",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "lspServers": "./.lsp.json"
 }
 ```
 
@@ -194,7 +195,8 @@ Use the appropriate scaffolder for each component type. Apply these cross-cuttin
 - Body written as instructions FOR Claude, not to the user
 - `description` under 60 chars, `argument-hint` documents all args
 - `allowed-tools` restricted to minimum needed
-- Use `${CLAUDE_PLUGIN_ROOT}` for all plugin-relative paths
+- Use `${CLAUDE_PLUGIN_ROOT}` for scripts/binaries bundled with the plugin (read-only in update)
+- Use `${CLAUDE_PLUGIN_DATA}` for persistent state (e.g., `node_modules`, python venv) that survives updates
 
 **Agents (use create-sub-agent):**
 - 3+ `<example>` blocks in description (Context/user/assistant format)
@@ -212,6 +214,7 @@ Use the appropriate scaffolder for each component type. Apply these cross-cuttin
 - Use quick-exit pattern in hooks: `if [ ! -f "$STATE_FILE" ]; then exit 0; fi`
 - Parse frontmatter with: `sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$FILE"`
 - Document restart requirement: settings changes need Claude Code restart
+- **Plugin settings.json**: Use at plugin root to set defaults (e.g., `{"agent": "default-agent"}`)
 
 ---
 

--- a/plugins/agent-scaffolders/skills/create-skill/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-skill/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-skill
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user wants to "create a skill", "add a skill",
   "write a new skill", "build a skill for my plugin", "scaffold a skill", "make a skill
@@ -11,7 +10,6 @@ description: >
   eval/iterate loop if a draft already exists. Do NOT use this for creating sub-agents
   (use create-sub-agent), slash commands (use create-command), or hooks
   (use create-hook).
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/create-stateful-skill/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-stateful-skill/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-stateful-skill
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   Interactive initialization script that generates an advanced Agent Skill utilizing L4 State
   Management, Lifecycle Artifacts, Tone Configuration, and Chained Commands. Trigger with

--- a/plugins/agent-scaffolders/skills/create-sub-agent/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-sub-agent/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: create-sub-agent
-accreditation: Patterns, examples, and terminology gratefully adapted from Anthropic public plugin-dev and skill-creator repositories.
 description: >
   This skill should be used when the user asks to "create an agent", "add an agent",
   "write a subagent", "build a new agent", "make me an agent that...", "add an agent
@@ -40,7 +39,6 @@ description: >
   Plugin and agentic OS context. create-sub-agent handles agent file generation.
   </commentary>
   </example>
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 

--- a/plugins/agent-scaffolders/skills/manage-marketplace/CONNECTORS.md
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/CONNECTORS.md
@@ -1,0 +1,3 @@
+# Connectors - manage-marketplace
+
+No external connectors required for execution. This skill is purely instructional and governs config definitions.

--- a/plugins/agent-scaffolders/skills/manage-marketplace/SKILL.md
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: manage-marketplace
+description: >
+  This skill should be used when the user wants to "create a marketplace", 
+  "setup a marketplace catalog", "scaffold marketplace.json", or "initialize 
+  a plugin registry". Use this even if they just mention "setting up a marketplace".
+allowed-tools: Bash, Read, Write
+---
+
+# Marketplace Manager
+
+Guidelines for authoring, appending, and distributing plugin marketplace catalogs.
+
+## Step 1: Initialize the Marketplace
+
+To create a new marketplace:
+1.  **Create directory**: Create a dedicated git repository or local path for the catalog.
+2.  **Create config directory**: Create a `.claude-plugin/` directory at the root.
+3.  **Create catalog file**: Create a `marketplace.json` file inside `.claude-plugin/`.
+4.  Add basic setup metadata (**name must be kebab-case**):
+    ```json
+    {
+      "name": "my-marketplace",
+      "owner": {
+        "name": "My Name"
+      },
+      "plugins": []
+    }
+    ```
+
+## Step 2: Add Plugin Entries
+
+To add entries to your marketplace `plugins` list:
+1.  Define the **`name`** (kebab-case).
+2.  Specify the **`source`** Type:
+    - **Relative path**: `"./plugins/my-plugin-folder"` (Warning: Only works if the marketplace is installed via Git clone or local path, not direct URL).
+    - **GitHub**: `{"source": "github", "repo": "owner/repo", "ref": "branch", "sha": "commit-sha"}`
+3.  Set **`strict`** to `true` to let the plugin's own manifest control definition lookup.
+
+> **💡 Plugin Author Note**: When writing hooks or server configs, use `${CLAUDE_PLUGIN_ROOT}` (read-only install path) and `${CLAUDE_PLUGIN_DATA}` (persistent state directory) instead of absolute host paths.
+
+---
+
+## Step 3: Distribution
+
+### Independent hosting
+1. Commit `.claude-plugin/marketplace.json` to a Git repo.
+2. Share absolute Git or HTTPS URL.
+3. Users run: `/plugin marketplace add <URL>`
+
+---
+
+## Step 4: Install Plugins (Consumer)
+
+Consumers add the marketplace, then install using correct scopes:
+- `/plugin install <name>` (Global **`user`** scope)
+- `/plugin install <name> --scope project` (Team shared)
+- `/plugin install <name> --scope local` (Machine local)
+
+---
+
+## References & Examples
+
+- [references/marketplace-schema.md](./references/marketplace-schema.md) - Struct, vars, and strict overrides.
+- [examples/marketplace.json](./examples/marketplace.json) - Working sample with GitHub lookup.

--- a/plugins/agent-scaffolders/skills/manage-marketplace/evals/evals.json
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/evals/evals.json
@@ -1,0 +1,18 @@
+[
+  {
+    "query": "I need help using the manage-marketplace skill",
+    "should_trigger": true
+  },
+  {
+    "query": "Can you use the manage-marketplace skill for me?",
+    "should_trigger": true
+  },
+  {
+    "query": "What time is it in New York?",
+    "should_trigger": false
+  },
+  {
+    "query": "How do I boil an egg?",
+    "should_trigger": false
+  }
+]

--- a/plugins/agent-scaffolders/skills/manage-marketplace/evals/results.tsv
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/evals/results.tsv
@@ -1,0 +1,1 @@
+iteration	train_score	test_score	decision	notes	description

--- a/plugins/agent-scaffolders/skills/manage-marketplace/examples/marketplace.json
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/examples/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "acme-corp-developer-tooling",
+  "owner": {
+    "name": "Acme Corp"
+  },
+  "plugins": [
+    {
+      "name": "internal-db-helper",
+      "source": "./plugins/internal-db-helper",
+      "strict": true,
+      "category": "Data",
+      "tags": ["sql", "helper"]
+    },
+    {
+      "name": "slack-bot-connector",
+      "source": {
+        "source": "github",
+        "repo": "acme-corp/slack-bot",
+        "ref": "main"
+      },
+      "strict": false,
+      "category": "Integrations"
+    }
+  ]
+}

--- a/plugins/agent-scaffolders/skills/manage-marketplace/manage-marketplace-flow.mmd
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/manage-marketplace-flow.mmd
@@ -1,0 +1,5 @@
+stateDiagram-v2
+    [*] --> Init
+    Init --> Process : Execute manage-marketplace
+    Process --> [*]
+    

--- a/plugins/agent-scaffolders/skills/manage-marketplace/references/acceptance-criteria.md
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/references/acceptance-criteria.md
@@ -1,0 +1,21 @@
+# Acceptance Criteria - manage-marketplace
+
+To verify the skill correctly guides the user in setting up and managing a marketplace.
+
+| Scenario | Expected Result | Pass/Fail |
+|----------|-----------------|-----------|
+| **Setup location** | The guide directs the user to place `marketplace.json` inside a `.claude-plugin/` directory at root. | **PASS** |
+| **Owner field** | The `owner` field is created and defined as an object: `{"name": "Owner Name"}`. | **PASS** |
+| **Name Field** | The `name` field strictly uses **kebab-case** validation. | **PASS** |
+| **CLI Directives** | The guide references addition using `/plugin marketplace add` TUI behavior directives. | **PASS** |
+| **Variables mapping** | The guide lists `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}` absolute references mapped safely for author hooks. | **PASS** |
+
+## Failure Patterns (FAIL)
+
+| Scenario | Incorrect Result |
+|----------|-----------------|
+| **Wrong file location** | Agent places `marketplace.json` at the repo root without a `.claude-plugin/` parent directory. |
+| **String `owner` field** | Generated catalog uses `"owner": "Acme Corp"` instead of `"owner": {"name": "Acme Corp"}`. |
+| **Non-kebab-case name** | Generated catalog uses names with spaces or mixed case (e.g., `"My Plugin"` or `"MyPlugin"`). |
+| **Wrong CLI command** | Skill tells consumers to run `claude plugins add-marketplace` or any other non-canonical command. |
+| **Hardcoded paths in hooks** | Plugin author guidance uses absolute host paths (e.g., `/home/user/.claude/plugins/my-plugin/run.sh`) instead of `${CLAUDE_PLUGIN_ROOT}`. |

--- a/plugins/agent-scaffolders/skills/manage-marketplace/references/architecture.md
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/references/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Reference - manage-marketplace
+
+The marketplace skill governs the catalog creation setup enabling custom package hosting.
+
+## Core Concepts
+
+### 1. Catalog Registry (`.claude-plugin/marketplace.json`)
+-   **Placement**: Positioned inside `.claude-plugin/` folder to satisfy manifest discovery layouts.
+-   **Structure**: Relies on relative definitions or standard source scopes (GitHub object maps).
+
+### 2. Caching Scopes & Caches
+-   Plugins distributed are copied to an internal user/project scope cache safely.
+-   **Variables**: absolute paths must use absolute variables (`${CLAUDE_PLUGIN_ROOT}`) to bridge cached isolation properly.
+
+### 3. Relative Path Source Limitation
+
+A marketplace entry with `"source": "./plugins/my-plugin"` resolves the path relative to the marketplace repository root. This only works when the marketplace was added via a Git clone or local filesystem path. It does NOT work when added via a direct raw URL to `marketplace.json`, because there is no filesystem root to resolve the relative path against.
+
+### 4. `strict` Field Behavior
+
+| `strict` value | Authority |
+|---------------|-----------|
+| `true` (default) | Plugin's own `.claude-plugin/plugin.json` is the source of truth. Marketplace entry supplements but does not override. |
+| `false` | Marketplace entry is the complete definition. Useful for overriding plugin metadata for a specific distribution. |
+
+### 5. Lifecycle
+The 2-step consumer process (Add & Install) is natively supported by Claude Code CLI and TUI (`/plugin`).

--- a/plugins/agent-scaffolders/skills/manage-marketplace/references/marketplace-schema.md
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/references/marketplace-schema.md
@@ -1,0 +1,67 @@
+# Marketplace Schema Reference
+
+A `.claude-plugin/marketplace.json` defines a catalog of distributable plugins.
+
+## Schema Structure
+
+```json
+{
+  "name": "marketplace-name",
+  "owner": {
+    "name": "Owner Name"
+  },
+  "plugins": [
+    {
+      "name": "plugin-name",
+      "source": "source-definition",
+      "strict": true,
+      "category": "category-name",
+      "tags": ["tag1", "tag2"]
+    }
+  ]
+}
+```
+
+### Plugin Source Types
+
+| Source Type | Format | Example |
+|-------------|--------|---------|
+| Relative Path | String | `"./plugins/my-plugin"` |
+| GitHub | Object | `{"source": "github", "repo": "owner/repo", "ref": "main", "sha": "commit-sha"}` |
+
+### Field Details
+
+- **`name`**: Marketplace identifier (**must be kebab-case**).
+- **`owner`**: Object containing a `name` field describing the maintainer.
+- **`strict`**: Boolean (default `true`).
+    - `true`: The plugin's internal `plugin.json` is the authority.
+    - `false`: The marketplace entry is the entire definition, allowing overrides.
+- **`category`**: Groups plugins by category for UI filtering.
+- **`tags`**: Filtering support.
+
+---
+
+## Installation Scopes
+
+When installing plugins, you can specify one of these scopes with `--scope`:
+- **`user`** (Default): Global access across all projects (`~/.claude/settings.json`).
+- **`project`**: Checked into repository for team sharing (`.claude/settings.json`).
+- **`local`**: Specific to current machine but git-ignored (`.claude/settings.local.json`).
+
+---
+
+## Distribution Modes
+
+### Independent Hosting
+1. Create a GitHub/Git repository.
+2. Commit `marketplace.json` inside a `.claude-plugin/` directory at the root.
+3. Share the Absolute HTTPS Git URL with consumers.
+
+
+---
+
+## Consumer Lifecycle (2-Step Process)
+
+To use your marketplace, consumers run:
+1. **Add Marketplace**: `/plugin marketplace add <repo-or-path>` (Registers the catalog).
+2. **Install Plugin**: `/plugin install <plugin-name>` (Installs individual items cached from sources).

--- a/plugins/agent-scaffolders/skills/manage-marketplace/scripts/execute.py
+++ b/plugins/agent-scaffolders/skills/manage-marketplace/scripts/execute.py
@@ -1,0 +1,1 @@
+# Template failed to load

--- a/plugins/agent-skill-open-specifications/.claude-plugin/plugin.json
+++ b/plugins/agent-skill-open-specifications/.claude-plugin/plugin.json
@@ -6,5 +6,12 @@
         "name": "Richard Fremmerlid"
     },
     "repository": "https://github.com/richfrem/agent-plugins-skills",
-    "license": "MIT"
+    "license": "MIT",
+    "keywords": [
+        "ecosystem-specs",
+        "plugin-standards",
+        "skill-standards",
+        "authoritative-reference",
+        "agent-skills"
+    ]
 }

--- a/plugins/agent-skill-open-specifications/README.md
+++ b/plugins/agent-skill-open-specifications/README.md
@@ -1,17 +1,30 @@
 # Agent Skill Open Specifications Meta-Plugin
 
 ## Installation
-### Option 1: Skills Only (End Users)
+
+### Option 1: From a Marketplace (Recommended)
+```bash
+/plugin marketplace add <marketplace-url>
+/plugin install agent-skill-open-specifications
+```
+For skills-only portability across all agents (Claude, Gemini, Copilot, etc.):
+```bash
+npx skills add <marketplace-url>/plugins/agent-skill-open-specifications
+```
+
+### Option 2: From GitHub Directly
+```bash
+# Skills only
+npx skills add richfrem/agent-plugins-skills --path plugins/agent-skill-open-specifications
+
+# Full plugin (Claude Code native)
+/plugin marketplace add richfrem/agent-plugins-skills
+/plugin install agent-skill-open-specifications
+```
+
+### Option 3: Local Development Checkout
 ```bash
 npx skills add ./plugins/agent-skill-open-specifications
-```
-This installs the skills from this plugin.
-
-### Option 2: Full Deployment (Skills + Commands + Agents)
-For complete access to all components, use the bridge-plugin skill:
-```bash
-# Use the bridge-plugin skill to deploy all components
-# python ./plugins/plugin-manager/scripts/bridge_installer.py --plugin plugins/agent-skill-open-specifications
 ```
 
 ## Purpose

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/SKILL.md
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ecosystem-authoritative-sources
 description: Provides information about how to create, structure, install, and audit Agent Skills, Plugins, Antigravity Workflows, and Sub-agents. Trigger this when specifications, rules, or best practices for the ecosystem are required.
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 ---
 
@@ -93,7 +92,8 @@ To read any of the reference guides, use your file system tools to `cat` or `vie
 
 ## Anthropic Plugin-Dev Key Learnings (March 2026)
 The following patterns were confirmed from Anthropic's official `plugin-dev` plugin:
-- **`${CLAUDE_PLUGIN_ROOT}`**: Required for all absolute path references inside plugin scripts/hooks (portability).
+- **`${CLAUDE_PLUGIN_ROOT}`**: Absolute path to the plugin's installation directory (read-only during updates).
+- **`${CLAUDE_PLUGIN_DATA}`**: Persistent directory for plugin state (e.g., node_modules, venv) that survives updates.
 - **Prompt-based hooks**: LLM-driven hooks run in parallel; use for semantic decisions. Command-based hooks for deterministic validation.
 - **`model: inherit`**: Default for sub-agents. Explicitly setting a model pins the agent to a version.
 - **`<example>` blocks**: Use 2-4 `<example>` blocks in agent frontmatter descriptions for richer trigger context (including proactive and negative instructions).

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/diagrams/plugin-architecture.mmd
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/diagrams/plugin-architecture.mmd
@@ -11,10 +11,11 @@ graph TD
     
     A --> J[agents/]
     A --> K[commands/]
-    A --> L[hooks.json]
-    A --> M[mcp.json]
-    A --> N[lsp.json]
-    A --> O[README.md]
+    A --> L[hooks/hooks.json]
+    A --> M[.mcp.json]
+    A --> N[.lsp.json]
+    A --> O[settings.json]
+    A --> P[README.md]
     
     style A fill:#f9f,stroke:#333,stroke-width:2px
     style B fill:#bbf,stroke:#333

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/marketplace.md
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/marketplace.md
@@ -21,8 +21,8 @@ Each entry in the `plugins` array defines how a specific plugin is fetched. You 
 - `source` (required): Where to fetch the plugin. Can be:
     - Relative Path: `"./plugins/my-plugin"` (Note: only works if the marketplace itself was installed via a Git repository clone or local path, not a direct URL).
     - GitHub Source: `{"source": "github", "repo": "owner/repo", "ref": "branch", "sha": "commit-hash"}`.
-- `strict`: Boolean controlling whether the plugin's internal `plugin.json` is the authority (`true`, default), or if the marketplace entry is the entire definition (`false`), overriding the plugin's native manifest.
-- Custom component paths: The marketplace entry can also specify paths to `commands`, `agents`, `hooks`, etc., relative to the plugin's root. For paths referencing files after the plugin is cached, the `plugins` variable can be used.
+- `strict`: Boolean controlling whether the plugin's internal `plugin.json` is the authority (`true`, default), or if the marketplace entry is the entire definition (`false`).
+- Custom component paths: The marketplace entry can specify paths to `commands`, `agents`, `hooks`, etc., relative to the plugin's root. For paths referencing files after the plugin is cached, use variables like `${CLAUDE_PLUGIN_ROOT}` or `${CLAUDE_PLUGIN_DATA}` in hooks or server configs.
 
 ## Discovery and Installation
 
@@ -43,4 +43,8 @@ Once a marketplace catalog is added, individual plugins can be installed into sp
 
 ### Prebuilt & Official Tooling
 - **Anthropic Official Marketplace (`claude-plugins-official`)**: Pre-installed. Discoverable under the Discover tab. Notably hosts Code Intelligence plugins (e.g., `typescript-lsp`, `python-lsp`) and External Integrations (e.g., `github`, `slack`, `figma`).
-- **Code Intelligence Plugins**: LSP plugins only configure the connection to the Language Server; the underlying binary (like `pyright` or `typescript-language-server`) MUST be installed manually by the user in their OS `$PATH`.
+- Code Intelligence Plugins: LSP plugins configure the connection to the Language Server; the binary MUST be installed manually in the OS `$PATH`.
+
+## Static Seeding & Restrictions
+- **Static Seeding (`CLAUDE_CODE_PLUGIN_SEED_DIR`):** Pre-populate plugins in containers/CI to avoid runtime cloning.
+- **Enterprise Restrictions (`strictKnownMarketplaces`):** Admins can restrict added marketplaces using allowlists (exact match, hostPattern, pathPattern) in managed settings.

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/plugins.md
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/references/plugins.md
@@ -9,7 +9,7 @@ Plugins let you extend Claude Code with custom functionality (skills, agents, ho
 
 ## Directory Structure
 Plugins must follow a strict root-level structure:
-- `./plugin.json`: The manifest (must only contain `plugin.json`).
+- `.claude-plugin/plugin.json`: The manifest.
 - `README.md`: Included as a best practice. It is highly recommended to contain a text-based file tree structure (using `├──` and `└──`) detailing the components inside the plugin and their purpose.
 
 *See visual representation in [plugin-architecture.mmd](./plugin-architecture.mmd)*
@@ -23,14 +23,15 @@ Plugins must follow a strict root-level structure:
 
 ## Environment Variables & Caching
 - **Plugin Cache:** Installed marketplace plugins are copied to a cache (`~/.claude/plugins/cache`).
-- **`plugins`:** Always use this environment variable inside `hooks.json`, `.mcp.json`, and scripts to reference the absolute path of your plugin (e.g. `"../../execute.sh"`).
+- **`${CLAUDE_PLUGIN_ROOT}`:** Absolute path to the plugin's installation directory. Use for referencing scripts or configuration files bundled with the plugin (read-only during updates).
+- **`${CLAUDE_PLUGIN_DATA}`:** Persistent directory for plugin state (e.g., `node_modules`, venv) that survives updates.
 
 ## Installation Scopes
 `user` (global), `project` (team, `.claude/settings.json`), `local` (git-ignored), `managed` (read-only).
 
 ## plugin.json Manifest Schema
 
-The manifest lives at `./plugin.json` (hyphen, not underscore).
+The manifest lives at `.claude-plugin/plugin.json` (inside the `.claude-plugin/` directory).
 
 **Required (only `name` is truly required):**
 ```json
@@ -63,12 +64,12 @@ The manifest lives at `./plugin.json` (hyphen, not underscore).
 }
 ```
 
-**Metadata Arrays (FORBIDDEN IN PLUGIN.JSON):**
+**Metadata Array Overrides (Supported):**
 
-> **⚠️ WARNING: STRICT SCHEMA VALIDATION**
-> Claude Code uses extremely strict JSON schema validation for `plugin.json`. If you include unrecognized root-level properties (like `skills`, `scripts`, `dependencies`, `commands_dir`, etc.), it will silently fail to parse the plugin and **none** of your skills or agents will appear in the UI. 
-> 
-> You MUST NOT include these arrays in `plugin.json`. Instead, document your skills, scripts, and dependencies in the plugin's `README.md` file.
+The `plugin.json` supports configuring custom component paths to supplement auto-discovery:
+- `commands`, `agents`, `skills`, `hooks`, `mcpServers`, `lspServers`, `outputStyles`
+
+These can map to single file paths or arrays of paths. Unrecognized root-level properties outside the schema should be avoided to prevent parsing issues.
 
 **Schema rules:**
 - `name` must be kebab-case (lowercase, hyphens, no spaces)

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-standards/SKILL.md
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-standards/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: ecosystem-standards
 description: Provides active execution protocols to rigorously audit how code, directory structures, and agent actions comply with the authoritative ecosystem specs. Trigger when validating new skills, plugins, or workflows.
-disable-model-invocation: false
 allowed-tools: Bash, Read, Write
-dependencies: ["skill:ecosystem-authoritative-sources"]
 ---
 
 ## Dependencies


### PR DESCRIPTION
Systematic cross-plugin review and remediation across agent-agentic-os, agent-plugin-analyzer, agent-scaffolders, and agent-skill-open-specifications.

Key changes:
- Remove non-standard SKILL.md frontmatter: accreditation, disable-model-invocation, model: inherit, color, tools (array), skills, dependencies fields
- Add allowed-tools to skills missing it; fix continuous-skill-optimizer which had disable-model-invocation but no allowed-tools
- Fix create-azure-agent broken/duplicated frontmatter block
- Add name + description to user-invocable skills (mine-plugins, mine-skill, self-audit) so they can be triggered by natural language in addition to slash commands
- Add keywords arrays to agent-plugin-analyzer and agent-skill-open-specifications plugin.json
- Fix agent-scaffolders plugin.json: remove empty agents/hooks/commands arrays and trailing comma (was invalid JSON)
- Rewrite all 4 README installation sections with 3-option marketplace-aware pattern
- Add new manage-marketplace skill to agent-scaffolders with full reference docs: marketplace-schema.md, acceptance-criteria.md, architecture.md, CONNECTORS.md, and examples/marketplace.json with correct owner object and kebab-case name
- Fix manage-marketplace schema: owner as object, valid source types only, scopes table
- Add agentic-os README marketplace installation instructions
- Add Prerequisites section to session-memory-manager (requires agentic-os-init first)
- Fix os-clean-locks: add kernel.py availability guard