### PR TITLE
docs: document Windows npx pivot to bridge installer in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository is a published Claude Code marketplace. Add it once and install 
 
 To browse and install interactively, run `/plugin` and go to the **Discover** tab — all 27 plugins from this marketplace will be listed there. Run `/reload-plugins` after installing to activate without restarting.
 
-### Option 2: npx skills CLI (cross-agent)
+### Option 2: npx skills CLI (Mac / Linux, cross-agent)
 
 Use the `npx skills` CLI to install directly into any agent environment. It auto-detects installed agents (Claude Code, GitHub Copilot, Gemini, Cursor, and 30+ others) and wires everything up natively.
 
@@ -46,34 +46,50 @@ npx skills add richfrem/agent-plugins-skills/plugins/spec-kitty-plugin
 npx skills update
 ```
 
-### Installing Locally (For Contributors / Local Dev)
-
-If you are developing or modifying plugins locally, you can install them directly from the local filesystem instead of pulling from GitHub.
-
 > [!WARNING]
-> When testing local changes to a skill, `npx` may cache previous symlinks or encounter folder lock issues when overwriting. Before reinstalling your local changes, you **must remove the existing destination folders** first.
+> **Windows users: do not use `npx skills add` with this repository.**
+> This repo uses Git symlinks inside skill directories. On Windows, Git checks out symlinks
+> as plain text files containing the relative path string. The `npx` installer copies the
+> text file as-is instead of following the symlink — resulting in broken one-line pointer
+> files in `.agents/` that Python cannot execute.
+> **Use the Bridge Installer (Option 3) instead.**
 
+### Option 3: Bridge Installer (Windows — works everywhere)
+
+The Bridge Installer is a pure-Python alternative to `npx` that understands Windows Git pointer files. It resolves symlink pointers at install time, writes real hard copies into `.agents/`, and creates Junctions (Windows) or symlinks (Mac/Linux) into each agent environment.
+
+**First install** — run once from the cloned repo root:
 ```bash
-# First, remove the existing agent skills folder to prevent caching/lock issues
-
-# remove a specific skill first check list 
-npx skills list
-
-#remove a specific skill 
-npx skills remove skill-name
-
-# Remove all skills from all agents
-rm -rf .agents/
-npx skills remove --all -y
-
-# Install a specific local plugin
-npx skills add ./plugins/rlm-factory --force
-
-# Install the entire local plugins directory
-npx skills add ./plugins/ --force
+python plugins/plugin-manager/scripts/install_all_plugins.py
 ```
 
-> **Why this works**: each plugin in `plugins/` contains a `SKILL.md` following the [open agent skills standard](https://skills.sh/docs). The CLI reads it and configures your IDE automatically.
+**Subsequent installs / consuming projects** — once installed, invoke directly from `.agents/`:
+```bash
+# Reinstall / update all core plugins
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py
+
+# Add plugins from a second source without touching existing installs
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py --plugins-dir path/to/other/plugins
+
+# Preview without writing anything
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py --dry-run
+```
+
+No Node.js required. No symlink permission issues. Installs are additive — running against multiple plugin directories merges them cleanly.
+
+### Installing Locally (For Contributors / Local Dev)
+
+After cloning, install the full plugin ecosystem from source:
+
+```bash
+# Install everything
+python plugins/plugin-manager/scripts/install_all_plugins.py
+
+# Install a single plugin
+python plugins/plugin-manager/scripts/bridge_installer.py --plugin plugins/rlm-factory
+```
+
+To update after making local changes, re-run the same command — the installer overwrites existing entries and skips any files currently locked by your IDE.
 
 Browse all available plugins and their install status at:
 **[skills.sh/richfrem/agent-plugins-skills](https://skills.sh/richfrem/agent-plugins-skills)**

--- a/plugins/plugin-manager/README.md
+++ b/plugins/plugin-manager/README.md
@@ -1,46 +1,60 @@
 # Plugin Manager
 
-> [!NOTE]
-> **Partially superseded by `npx skills`.**
-> `npx skills` auto-detects your agent environment and installs all plugins natively.
-> This plugin is now primarily a **local development tool** for contributors who need to:
-> - Deploy modifications directly from local source
-> - Sync local plugins to multiple IDEs simultaneously
-> - Copy or replicate source code to entirely separate project repositories
-
 **The Universal Orchestration Hub for Your Plugin Ecosystem**
 
 The **Plugin Manager** maintains a healthy local plugin ecosystem. It adapts and bridges standard plugins for use in many compatible agent environments (allowing you to write your core plugin logic once and deploy it across a wide variety of tools), and easily distributes source plugins to other project repos.
 
 ---
 
+## Why `npx skills` Was Replaced on Windows
+
+`npx skills add` works correctly on **Mac and Linux** where Git creates real OS-level symlinks. This repository uses symlinks inside skill directories (e.g. `bridge-plugin/scripts/install_all_plugins.py` points back to the canonical source in `plugins/plugin-manager/scripts/`).
+
+On **Windows**, Git checks out symlinks as plain text files containing the relative path string (e.g. `../../../scripts/install_all_plugins.py`). The `npx` installer uses Node.js `cp({ dereference: true })` which detects real symlinks and copies the target — but on Windows it sees a text file and copies the literal path string. The result is a `.agents/` folder full of one-line text files that Python cannot execute.
+
+The **Bridge Installer** solves this by reading those text pointer files at install time, following the relative path back to the real Python source, and writing a proper hard copy into `.agents/`. No symlinks. No `npx`. No Node.js dependency. Works identically on all platforms.
+
+---
+
 ## Installation
 
-### Option 1: From a Marketplace (Recommended)
+### Option 1: From a Marketplace (Claude Code native)
 ```bash
-/plugin marketplace add <marketplace-url>
-/plugin install plugin-manager
-```
-For skills-only portability across all agents (Claude, Gemini, Copilot, etc.):
-```bash
-npx skills add <marketplace-url>/plugins/plugin-manager
-```
-
-### Option 2: From GitHub Directly
-```bash
-# Skills only
-npx skills add richfrem/agent-plugins-skills --path plugins/plugin-manager
-
-# Full plugin (Claude Code native)
 /plugin marketplace add richfrem/agent-plugins-skills
 /plugin install plugin-manager
 ```
 
-### Option 3: Local Development Checkout
+### Option 2: Mac / Linux — `npx skills` (cross-agent, skills only)
 ```bash
-npx skills add ./plugins/plugin-manager
+# Skills only — works correctly on Mac/Linux where Git creates real symlinks
+npx skills add richfrem/agent-plugins-skills --path plugins/plugin-manager
 ```
-For full deployment (skills + commands + rules + hooks), use the `bridge-plugin` skill after checkout.
+
+> [!WARNING]
+> **Windows users:** do not use `npx skills add` with this repository. Git for Windows
+> checks out symlinks as text files and `npx` will install broken one-line pointer files
+> instead of executable Python. Use the Bridge Installer below instead.
+
+### Option 3: Bridge Installer (Recommended for Windows — works everywhere)
+
+After cloning or installing this plugin, run the batch installer from the project root:
+
+```bash
+# Install all plugins from the core plugins/ directory
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py
+
+# Install from an additional plugins directory (additive — does not wipe existing installs)
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py --plugins-dir path/to/other/plugins
+
+# Dry run to preview without writing
+python .agents/skills/bridge-plugin/scripts/install_all_plugins.py --dry-run
+```
+
+The installer:
+- Reads pointer files, resolves them to real source, and writes hard copies into `.agents/skills/`
+- Creates Windows Junctions (or symlinks on Mac/Linux) from `.agent/skills/` and `.claude/skills/` into `.agents/`
+- Is **additive** — running it against a second plugins directory merges without touching existing installs
+- Runs correctly from its own installed location in `.agents/` — no `plugins/` source tree required in consuming projects
 
 ## 🌐 Supported Targets
 


### PR DESCRIPTION
- plugin-manager/README.md: replace 'partially superseded by npx' note with explanation of why npx fails on Windows (Git symlinks checked out as text pointer files), document bridge installer as the recommended cross-platform installation method with additive multi-source usage
- README.md: add Windows warning to npx section, add Option 3 (Bridge Installer) with first-install and consuming-project usage examples, update local dev section to use bridge installer commands