### PR TITLE
harden: normalize plugins/ path refs to consumer-safe .agents/skills/…

### DIFF
--- a/.agents/agents/claude-cli-claude-cli-agent.md
+++ b/.agents/agents/claude-cli-claude-cli-agent.md
@@ -79,7 +79,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/agents/coding-conventions-coding-conventions-agent.md
+++ b/.agents/agents/coding-conventions-coding-conventions-agent.md
@@ -30,12 +30,12 @@ You enforce coding conventions and documentation standards for all code in the p
 3. **Type hints** — all Python function signatures use type annotations
 4. **Naming** — `snake_case` (Python), `camelCase` (JS/TS), `PascalCase` (C# public)
 5. **Refactor threshold** — 50+ lines or 3+ nesting levels → extract helpers
-6. **Tool registration** — all `plugins/` scripts registered in `plugins/tool_inventory.json`
+6. **Tool registration** - all project scripts registered via the `tool-inventory` skill
 7. **Manifest schema** — use simple `{title, description, files}` format (ADR 097)
 
 ## 📂 Header Templates
-- **Python**: `plugins/templates/python-tool-header-template.py`
-- **JS/TS**: `plugins/templates/js-tool-header-template.js`
+- **Python**: `./scripts/python-tool-header-template.py` (in this skill's scripts/)
+- **JS/TS**: `./scripts/js-tool-header-template.js` (in this skill's scripts/)
 
 ## 📝 File Headers
 
@@ -149,11 +149,11 @@ module/
 
 ## 🛠️ Tool Inventory Integration
 
-All Python scripts in `plugins/` **must** be registered in `plugins/tool_inventory.json`.
+All project scripts **must** be registered in `tool_inventory.json` (tracked at project root).
 
 After creating or modifying a tool, trigger the `tool-inventory` skill to register the script and audit coverage.
 
 ### Pre-Commit Checklist
 - [ ] File has proper header
-- [ ] Script registered in `plugins/tool_inventory.json` (via `tool-inventory` skill)
+- [ ] Script registered in `tool_inventory.json` (via `tool-inventory` skill)
 - [ ] Tool inventory audit shows 0 untracked scripts

--- a/.agents/agents/copilot-cli-copilot-cli-agent.md
+++ b/.agents/agents/copilot-cli-copilot-cli-agent.md
@@ -136,7 +136,7 @@ For benchmark loops that call Copilot as the improvement backend, apply the same
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/agents/exploration-cycle-plugin-exploration-cycle-orchestrator-agent.md
+++ b/.agents/agents/exploration-cycle-plugin-exploration-cycle-orchestrator-agent.md
@@ -71,14 +71,14 @@ The requirements-doc-agent runs as a cheap Copilot CLI sub-agent. Call it once p
 ```bash
 # Pass 1: Problem framing
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, and goals." \
   --output exploration/captures/problem-framing.md
 
 # Pass 2: Business requirements
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, constraints." \
   --output exploration/captures/brd-draft.md
@@ -93,7 +93,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 # Pass 3: User stories
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set." \
   --output exploration/captures/user-stories-draft.md
@@ -106,28 +106,28 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 
 # Pass 4: Issues and opportunities (optional)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
 
 # Prototype observations (after prototype session)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Capture implied requirements, assumptions, and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md
 
 # Business Rule Audit (Logic Drift detection)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md exploration/captures/prototype-notes.md \
   --instruction "Audit the prototype behavior against the business rules. Detect logic drift." \
   --output exploration/captures/audit-findings.md
 
 # Synthesis for handoff
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/*.md \
   --instruction "Synthesize all captures into a handoff package." \
   --output exploration/handoff/exploration-handoff.md
@@ -135,21 +135,21 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: only if spec-kitty plugin is present ---------------------
 # Phase 5a: pre-draft spec.md (staging only)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft spec.md from this handoff. Mark gaps with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Phase 5b: pre-draft plan.md
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft plan.md with phases and WP hints. Mark gaps." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Phase 5c: WP tasks outline
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate WP outline. Stubs only." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -157,7 +157,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: re-entry from spec-kitty engineering cycle ---------------
 # Triggered when spec-kitty cycle uncovers unresolved ambiguity (cycling back)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Draft a session brief for a new cycle." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/agents/exploration-cycle-plugin-handoff-preparer-agent.md
+++ b/.agents/agents/exploration-cycle-plugin-handoff-preparer-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI with all capture documents piped as input:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \

--- a/.agents/agents/exploration-cycle-plugin-planning-doc-agent.md
+++ b/.agents/agents/exploration-cycle-plugin-planning-doc-agent.md
@@ -44,7 +44,7 @@ Pre-drafts `spec.md` from the handoff package. Output goes to staging — not di
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this exploration handoff. Follow Spec-Kitty spec format. Mark any gap with [NEEDS HUMAN INPUT]. Output to staging only." \
   --output exploration/planning-drafts/spec-draft.md
@@ -56,7 +56,7 @@ Pre-drafts `plan.md` with high-level phases and work package hints from the hand
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
@@ -68,7 +68,7 @@ Generates a first-pass work package outline (WP stubs) from the spec and plan dr
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline from these drafts. Use WP-XX format. Stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -80,7 +80,7 @@ When the spec-kitty engineering cycle encounters unresolved ambiguity, use this 
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe the ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type (spike / brownfield). Draft a session brief." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/agents/exploration-cycle-plugin-prototype-companion-agent.md
+++ b/.agents/agents/exploration-cycle-plugin-prototype-companion-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI after a prototype session. The piped input is the curren
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: prototype-observations. Capture implied requirements and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md

--- a/.agents/agents/gemini-cli-gemini-cli-agent.md
+++ b/.agents/agents/gemini-cli-gemini-cli-agent.md
@@ -76,7 +76,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/agents/rlm-factory-rlm-cleanup.md
+++ b/.agents/agents/rlm-factory-rlm-cleanup.md
@@ -27,7 +27,7 @@ its file no longer exists or has moved. Running this regularly keeps the ledger 
 
 ## Prerequisites
 
-**Profile not configured?** Run `rlm-init` skill first: `plugins/rlm-factory/skills/rlm-init/SKILL.md`
+**Profile not configured?** Run `rlm-init` skill first: `.agents/skills/rlm-init/SKILL.md`
 
 ## When to Run
 

--- a/.agents/agents/rlm-factory-rlm-distill.md
+++ b/.agents/agents/rlm-factory-rlm-distill.md
@@ -37,7 +37,7 @@ summary, and inject it into the ledger via `inject_summary.py`.
 
 **First-time setup or missing profile?** Run the `rlm-init` skill first:
 ```bash
-# See: plugins/rlm-factory/skills/rlm-init/SKILL.md
+# See: .agents/skills/rlm-init/SKILL.md
 # Creates rlm_profiles.json, manifest, and empty cache
 ```
 
@@ -62,7 +62,7 @@ and what are its key components/functions?"* in one dense sentence.
 ```bash
 python3 ./scripts/inject_summary.py \
   --profile project \
-  --file plugins/example/skills/my-skill/SKILL.md \
+  --file .agents/skills/my-skill/SKILL.md \
   --summary "Provides atomic vault CRUD operations for Obsidian notes using POSIX rename and fcntl.flock."
 ```
 
@@ -99,7 +99,7 @@ python3 ./scripts/swarm_run.py \
   --resume --workers 5
 ```
 
-See `plugins/agent-loops/skills/agent-swarm/SKILL.md` for full swarm configuration options.
+See `.agents/skills/agent-swarm/SKILL.md` for full swarm configuration options.
 
 ## Quality Standard for Summaries
 

--- a/.agents/skills/audit-plugin-l5/SKILL.md
+++ b/.agents/skills/audit-plugin-l5/SKILL.md
@@ -23,7 +23,7 @@ See `../../requirements.txt` for the dependency lockfile (currently empty — st
 This skill abstracts the execution of the L5 Enterprise Red Team Auditor. By using this skill, you trigger an uncompromising architecture and security review against the 39-point pattern matrix.
 
 ## Discovery Phase
-Before executing this skill, ensure you know the exact path or name of the plugin you wish to audit (e.g., `plugins/legacy system/xml-to-markdown`).
+Before executing this skill, ensure you know the exact path or name of the plugin you wish to audit (e.g., `plugins/oracle-legacy-system-analysis/xml-to-markdown`).
 
 ## Execution
 This skill delegates immediately to the `l5-red-team-auditor` sub-agent.

--- a/.agents/skills/auto-update-plugins/scripts/check_and_sync.py
+++ b/.agents/skills/auto-update-plugins/scripts/check_and_sync.py
@@ -57,10 +57,12 @@ def _compute_folder_hash(folder: Path) -> str:
 
     for root_dir, dirs, files in os.walk(folder):
         # Filter directories in-place to control walk recursion
-        dirs[:] = [
+        filtered = [
             d for d in dirs
             if not d.startswith(".") and d not in ("node_modules", "__pycache__")
         ]
+        dirs.clear()
+        dirs.extend(filtered)
         for f in files:
             file_list.append(Path(root_dir) / f)
 

--- a/.agents/skills/business-workflow-doc/SKILL.md
+++ b/.agents/skills/business-workflow-doc/SKILL.md
@@ -32,7 +32,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 ```bash
 cat exploration/session-brief.md exploration/captures/brd-draft.md \
-  | copilot -p "$(cat plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md)" \
+  | copilot -p "$(cat .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md)" \
     "Mode: workflow-map. Generate a Mermaid flowchart diagram of the core business process described in this context. Use a flowchart TD layout. Label each step clearly. Include decision nodes for branches and validation gates." \
   > exploration/captures/workflow-map.md
 ```

--- a/.agents/skills/claude-cli-agent/SKILL.md
+++ b/.agents/skills/claude-cli-agent/SKILL.md
@@ -79,7 +79,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/claude-cli-claude-cli-agent/SKILL.md
+++ b/.agents/skills/claude-cli-claude-cli-agent/SKILL.md
@@ -79,7 +79,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/coding-conventions-agent/SKILL.md
+++ b/.agents/skills/coding-conventions-agent/SKILL.md
@@ -30,12 +30,12 @@ You enforce coding conventions and documentation standards for all code in the p
 3. **Type hints** — all Python function signatures use type annotations
 4. **Naming** — `snake_case` (Python), `camelCase` (JS/TS), `PascalCase` (C# public)
 5. **Refactor threshold** — 50+ lines or 3+ nesting levels → extract helpers
-6. **Tool registration** — all `plugins/` scripts registered in `plugins/tool_inventory.json`
+6. **Tool registration** - all project scripts registered via the `tool-inventory` skill
 7. **Manifest schema** — use simple `{title, description, files}` format (ADR 097)
 
 ## 📂 Header Templates
-- **Python**: `plugins/templates/python-tool-header-template.py`
-- **JS/TS**: `plugins/templates/js-tool-header-template.js`
+- **Python**: `./scripts/python-tool-header-template.py` (in this skill's scripts/)
+- **JS/TS**: `./scripts/js-tool-header-template.js` (in this skill's scripts/)
 
 ## 📝 File Headers
 
@@ -149,11 +149,11 @@ module/
 
 ## 🛠️ Tool Inventory Integration
 
-All Python scripts in `plugins/` **must** be registered in `plugins/tool_inventory.json`.
+All project scripts **must** be registered in `tool_inventory.json` (tracked at project root).
 
 After creating or modifying a tool, trigger the `tool-inventory` skill to register the script and audit coverage.
 
 ### Pre-Commit Checklist
 - [ ] File has proper header
-- [ ] Script registered in `plugins/tool_inventory.json` (via `tool-inventory` skill)
+- [ ] Script registered in `tool_inventory.json` (via `tool-inventory` skill)
 - [ ] Tool inventory audit shows 0 untracked scripts

--- a/.agents/skills/coding-conventions-coding-conventions-agent/SKILL.md
+++ b/.agents/skills/coding-conventions-coding-conventions-agent/SKILL.md
@@ -30,12 +30,12 @@ You enforce coding conventions and documentation standards for all code in the p
 3. **Type hints** — all Python function signatures use type annotations
 4. **Naming** — `snake_case` (Python), `camelCase` (JS/TS), `PascalCase` (C# public)
 5. **Refactor threshold** — 50+ lines or 3+ nesting levels → extract helpers
-6. **Tool registration** — all `plugins/` scripts registered in `plugins/tool_inventory.json`
+6. **Tool registration** - all project scripts registered via the `tool-inventory` skill
 7. **Manifest schema** — use simple `{title, description, files}` format (ADR 097)
 
 ## 📂 Header Templates
-- **Python**: `plugins/templates/python-tool-header-template.py`
-- **JS/TS**: `plugins/templates/js-tool-header-template.js`
+- **Python**: `./scripts/python-tool-header-template.py` (in this skill's scripts/)
+- **JS/TS**: `./scripts/js-tool-header-template.js` (in this skill's scripts/)
 
 ## 📝 File Headers
 
@@ -149,11 +149,11 @@ module/
 
 ## 🛠️ Tool Inventory Integration
 
-All Python scripts in `plugins/` **must** be registered in `plugins/tool_inventory.json`.
+All project scripts **must** be registered in `tool_inventory.json` (tracked at project root).
 
 After creating or modifying a tool, trigger the `tool-inventory` skill to register the script and audit coverage.
 
 ### Pre-Commit Checklist
 - [ ] File has proper header
-- [ ] Script registered in `plugins/tool_inventory.json` (via `tool-inventory` skill)
+- [ ] Script registered in `tool_inventory.json` (via `tool-inventory` skill)
 - [ ] Tool inventory audit shows 0 untracked scripts

--- a/.agents/skills/concurrent-agent-loop/SKILL.md
+++ b/.agents/skills/concurrent-agent-loop/SKILL.md
@@ -91,8 +91,8 @@ Use Standard Cycle only when the north star is regressing or explicitly requeste
    | `memory.md` | LAB `context/` | Standard Cycle -- promoted L3 facts via session-memory-manager. |
    | `HOW-TO-RESTART.md` | UPSTREAM `temp/agent-agentic-os-review/` | Every cycle -- reflect state changes. |
    | `tasks/backlog/NNNN-[slug].md` | UPSTREAM `tasks/backlog/` | When M/L-class issue is observed. |
-   | `references/backlog.md` | UPSTREAM `plugins/agent-agentic-os/references/` | When any issue is observed (S/M/L). |
-   | **`SKILL.md` (this file)** | UPSTREAM `plugins/agent-agentic-os/skills/concurrent-agent-loop/` | **When applicable** -- if the loop produces a confirmed protocol improvement (step unclear, gap found, new requirement), ORCHESTRATOR updates this file before closing the cycle. Self-improvement of the loop protocol is a first-class output of every loop. |
+   | `references/backlog.md` | UPSTREAM `references/` | When any issue is observed (S/M/L). |
+   | **`SKILL.md` (this file)** | UPSTREAM `.agents/skills/concurrent-agent-loop/` | **When applicable** -- if the loop produces a confirmed protocol improvement (step unclear, gap found, new requirement), ORCHESTRATOR updates this file before closing the cycle. Self-improvement of the loop protocol is a first-class output of every loop. |
 
    A cycle that produces a protocol fix but does not update this SKILL.md has not fully closed.
 

--- a/.agents/skills/context-bundling/SKILL.md
+++ b/.agents/skills/context-bundling/SKILL.md
@@ -80,7 +80,7 @@ Instead of:
 ```json
 { "path": "plugins/agent-agentic-os/README.md", "note": "..." },
 { "path": "plugins/agent-agentic-os/SUMMARY.md", "note": "..." },
-{ "path": "plugins/agent-agentic-os/skills/agentic-os-guide/SKILL.md", "note": "..." },
+{ "path": ".agents/skills/agentic-os-guide/SKILL.md", "note": "..." },
 ...
 ```
 

--- a/.agents/skills/copilot-cli-agent/SKILL.md
+++ b/.agents/skills/copilot-cli-agent/SKILL.md
@@ -136,7 +136,7 @@ For benchmark loops that call Copilot as the improvement backend, apply the same
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/copilot-cli-copilot-cli-agent/SKILL.md
+++ b/.agents/skills/copilot-cli-copilot-cli-agent/SKILL.md
@@ -136,7 +136,7 @@ For benchmark loops that call Copilot as the improvement backend, apply the same
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/deferred/exploration-cycle-orchestrator-agent.md
+++ b/.agents/skills/deferred/exploration-cycle-orchestrator-agent.md
@@ -71,14 +71,14 @@ The requirements-doc-agent runs as a cheap Copilot CLI sub-agent. Call it once p
 ```bash
 # Pass 1: Problem framing
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, and goals." \
   --output exploration/captures/problem-framing.md
 
 # Pass 2: Business requirements
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, constraints." \
   --output exploration/captures/brd-draft.md
@@ -93,7 +93,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 # Pass 3: User stories
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set." \
   --output exploration/captures/user-stories-draft.md
@@ -106,28 +106,28 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 
 # Pass 4: Issues and opportunities (optional)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
 
 # Prototype observations (after prototype session)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Capture implied requirements, assumptions, and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md
 
 # Business Rule Audit (Logic Drift detection)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md exploration/captures/prototype-notes.md \
   --instruction "Audit the prototype behavior against the business rules. Detect logic drift." \
   --output exploration/captures/audit-findings.md
 
 # Synthesis for handoff
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/*.md \
   --instruction "Synthesize all captures into a handoff package." \
   --output exploration/handoff/exploration-handoff.md
@@ -135,21 +135,21 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: only if spec-kitty plugin is present ---------------------
 # Phase 5a: pre-draft spec.md (staging only)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft spec.md from this handoff. Mark gaps with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Phase 5b: pre-draft plan.md
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft plan.md with phases and WP hints. Mark gaps." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Phase 5c: WP tasks outline
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate WP outline. Stubs only." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -157,7 +157,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: re-entry from spec-kitty engineering cycle ---------------
 # Triggered when spec-kitty cycle uncovers unresolved ambiguity (cycling back)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Draft a session brief for a new cycle." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/skills/deferred/prototype-companion-agent.md
+++ b/.agents/skills/deferred/prototype-companion-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI after a prototype session. The piped input is the curren
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: prototype-observations. Capture implied requirements and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md

--- a/.agents/skills/ecosystem-authoritative-sources/SKILL.md
+++ b/.agents/skills/ecosystem-authoritative-sources/SKILL.md
@@ -43,7 +43,7 @@ are community conventions built on top of these primitives (not Anthropic-offici
 
 For bootstrapping Agentic OS in a project, use the `agentic-os-init` skill:
 ```
-plugins/agent-agentic-os/skills/agentic-os-init/SKILL.md
+.agents/skills/agentic-os-init/SKILL.md
 ```
 
 # The Library

--- a/.agents/skills/exploration-cycle-plugin-exploration-cycle-orchestrator-agent/SKILL.md
+++ b/.agents/skills/exploration-cycle-plugin-exploration-cycle-orchestrator-agent/SKILL.md
@@ -71,14 +71,14 @@ The requirements-doc-agent runs as a cheap Copilot CLI sub-agent. Call it once p
 ```bash
 # Pass 1: Problem framing
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, and goals." \
   --output exploration/captures/problem-framing.md
 
 # Pass 2: Business requirements
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, constraints." \
   --output exploration/captures/brd-draft.md
@@ -93,7 +93,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 # Pass 3: User stories
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set." \
   --output exploration/captures/user-stories-draft.md
@@ -106,28 +106,28 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 
 # Pass 4: Issues and opportunities (optional)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
 
 # Prototype observations (after prototype session)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Capture implied requirements, assumptions, and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md
 
 # Business Rule Audit (Logic Drift detection)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md exploration/captures/prototype-notes.md \
   --instruction "Audit the prototype behavior against the business rules. Detect logic drift." \
   --output exploration/captures/audit-findings.md
 
 # Synthesis for handoff
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/*.md \
   --instruction "Synthesize all captures into a handoff package." \
   --output exploration/handoff/exploration-handoff.md
@@ -135,21 +135,21 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: only if spec-kitty plugin is present ---------------------
 # Phase 5a: pre-draft spec.md (staging only)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft spec.md from this handoff. Mark gaps with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Phase 5b: pre-draft plan.md
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft plan.md with phases and WP hints. Mark gaps." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Phase 5c: WP tasks outline
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate WP outline. Stubs only." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -157,7 +157,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: re-entry from spec-kitty engineering cycle ---------------
 # Triggered when spec-kitty cycle uncovers unresolved ambiguity (cycling back)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Draft a session brief for a new cycle." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md
+++ b/.agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md
@@ -21,7 +21,7 @@ You are invoked via CLI with all capture documents piped as input:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \

--- a/.agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md
+++ b/.agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md
@@ -44,7 +44,7 @@ Pre-drafts `spec.md` from the handoff package. Output goes to staging — not di
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this exploration handoff. Follow Spec-Kitty spec format. Mark any gap with [NEEDS HUMAN INPUT]. Output to staging only." \
   --output exploration/planning-drafts/spec-draft.md
@@ -56,7 +56,7 @@ Pre-drafts `plan.md` with high-level phases and work package hints from the hand
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
@@ -68,7 +68,7 @@ Generates a first-pass work package outline (WP stubs) from the spec and plan dr
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline from these drafts. Use WP-XX format. Stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -80,7 +80,7 @@ When the spec-kitty engineering cycle encounters unresolved ambiguity, use this 
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe the ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type (spike / brownfield). Draft a session brief." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md
+++ b/.agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md
@@ -21,7 +21,7 @@ You are invoked via CLI after a prototype session. The piped input is the curren
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: prototype-observations. Capture implied requirements and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md

--- a/.agents/skills/exploration-handoff/handoff-preparer-agent.md
+++ b/.agents/skills/exploration-handoff/handoff-preparer-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI with all capture documents piped as input:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \

--- a/.agents/skills/exploration-workflow/SKILL.md
+++ b/.agents/skills/exploration-workflow/SKILL.md
@@ -102,7 +102,7 @@ Dispatch the requirements-doc-agent as a cheap CLI sub-agent. Each pass is focus
 ### Pass 1: Problem Framing
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, goals, and initial scope hypotheses." \
   --output exploration/captures/problem-framing.md
@@ -111,7 +111,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 ### Pass 2: Business Requirements
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, and constraints." \
   --output exploration/captures/brd-draft.md
@@ -127,7 +127,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
   --output exploration/captures/workflow-map.md
 # Then fan out to agent to populate the Mermaid skeleton:
 # python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-#   --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+#   --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
 #   --context exploration/captures/workflow-map.md \
 #   --instruction "Mode: workflow-map. Fill in the Mermaid diagram with actual process steps from the captures." \
 #   --output exploration/captures/workflow-map.md
@@ -136,7 +136,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 ### Pass 3: User Stories
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set from the requirements." \
   --output exploration/captures/user-stories-draft.md
@@ -156,7 +156,7 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 ### Pass 4: Issues and Opportunities (optional)
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
@@ -185,7 +185,7 @@ If exploration needs a runnable prototype to resolve ambiguity:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md \
   --instruction "Mode: prototype-observations. Capture implied requirements, assumptions, and edge cases observed." \
@@ -200,7 +200,7 @@ Run after prototype observations are captured and before the Narrowing Gate. Thi
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --optional-context exploration/captures/prototype-notes.md \
   --instruction "Run a full business rule audit. Compare all BR-xxx rules in the BRD against the prototype observations (if present). Produce a structured report with a required ## Unresolved Drifts section. List every rule with no corresponding evidence. If no prototype-notes are present, flag all rules as unverified." \
@@ -243,7 +243,7 @@ Synthesize all captures into a single handoff package:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \
@@ -270,21 +270,21 @@ This phase uses the [`planning-doc-agent`](../../agents/planning-doc-agent.md) t
 ```bash
 # Mode 1: spec-draft
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Mode 2: plan-draft
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Mode 3: tasks-outline (reads the two drafts above)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline. WP-XX stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -308,7 +308,7 @@ echo "CONTEXT: [describe the blocking ambiguity or engineering question here]" >
 
 # Step 2: dispatch
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context /tmp/reentry-context-$$.md \
   --instruction "Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type. Draft a session brief." \
   --output "exploration/session-brief-reentry-$(date +%Y%m%d).md"

--- a/.agents/skills/exploration-workflow/exploration-cycle-orchestrator-agent.md
+++ b/.agents/skills/exploration-workflow/exploration-cycle-orchestrator-agent.md
@@ -71,14 +71,14 @@ The requirements-doc-agent runs as a cheap Copilot CLI sub-agent. Call it once p
 ```bash
 # Pass 1: Problem framing
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, and goals." \
   --output exploration/captures/problem-framing.md
 
 # Pass 2: Business requirements
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, constraints." \
   --output exploration/captures/brd-draft.md
@@ -93,7 +93,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 # Pass 3: User stories
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set." \
   --output exploration/captures/user-stories-draft.md
@@ -106,28 +106,28 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 
 # Pass 4: Issues and opportunities (optional)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
 
 # Prototype observations (after prototype session)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Capture implied requirements, assumptions, and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md
 
 # Business Rule Audit (Logic Drift detection)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md exploration/captures/prototype-notes.md \
   --instruction "Audit the prototype behavior against the business rules. Detect logic drift." \
   --output exploration/captures/audit-findings.md
 
 # Synthesis for handoff
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/*.md \
   --instruction "Synthesize all captures into a handoff package." \
   --output exploration/handoff/exploration-handoff.md
@@ -135,21 +135,21 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: only if spec-kitty plugin is present ---------------------
 # Phase 5a: pre-draft spec.md (staging only)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft spec.md from this handoff. Mark gaps with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Phase 5b: pre-draft plan.md
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft plan.md with phases and WP hints. Mark gaps." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Phase 5c: WP tasks outline
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate WP outline. Stubs only." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -157,7 +157,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: re-entry from spec-kitty engineering cycle ---------------
 # Triggered when spec-kitty cycle uncovers unresolved ambiguity (cycling back)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Draft a session brief for a new cycle." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/skills/exploration-workflow/planning-doc-agent.md
+++ b/.agents/skills/exploration-workflow/planning-doc-agent.md
@@ -44,7 +44,7 @@ Pre-drafts `spec.md` from the handoff package. Output goes to staging — not di
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this exploration handoff. Follow Spec-Kitty spec format. Mark any gap with [NEEDS HUMAN INPUT]. Output to staging only." \
   --output exploration/planning-drafts/spec-draft.md
@@ -56,7 +56,7 @@ Pre-drafts `plan.md` with high-level phases and work package hints from the hand
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
@@ -68,7 +68,7 @@ Generates a first-pass work package outline (WP stubs) from the spec and plan dr
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline from these drafts. Use WP-XX format. Stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -80,7 +80,7 @@ When the spec-kitty engineering cycle encounters unresolved ambiguity, use this 
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe the ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type (spike / brownfield). Draft a session brief." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/.agents/skills/gemini-cli-agent/SKILL.md
+++ b/.agents/skills/gemini-cli-agent/SKILL.md
@@ -76,7 +76,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/gemini-cli-gemini-cli-agent/SKILL.md
+++ b/.agents/skills/gemini-cli-gemini-cli-agent/SKILL.md
@@ -76,7 +76,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/.agents/skills/loop-progress-report/SKILL.md
+++ b/.agents/skills/loop-progress-report/SKILL.md
@@ -71,7 +71,7 @@ This skill produces the same chart for agentic-os and exploration-cycle-plugin i
 | Source | Content |
 |--------|---------|
 | `context/memory/improvement-ledger.md` | Eval score progression (Section 1), survey-to-action trace (Section 2), north star metric (Section 3) |
-| `plugins/*/skills/*/evals/results.tsv` | Per-skill detailed eval score history (supplement to ledger) |
+| `.agents/skills/*/evals/results.tsv` | Per-skill detailed eval score history (supplement to ledger) |
 
 The improvement ledger is the primary source. It is written at every loop close (Stage 4.7
 of concurrent-agent-loop). See `references/improvement-ledger-spec.md` for the format.
@@ -108,7 +108,7 @@ Do not run the report script on an empty ledger — it will produce an empty cha
 ### Phase 2: Run the report
 
 ```bash
-PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-$(pwd)/plugins/agent-agentic-os}"
+PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-$(pwd)/.agents/skills/agent-agentic-os}"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 python3 "${PLUGIN_DIR}/skills/loop-progress-report/scripts/generate_report.py" \

--- a/.agents/skills/memory-management/SKILL.md
+++ b/.agents/skills/memory-management/SKILL.md
@@ -103,7 +103,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/rlm-factory/` |
+| **Plugin** | `.agents/skills/` (rlm-curator, rlm-search, rlm-init, rlm-distill-agent) |
 | **Skill (write)** | `skills/rlm-curator/` -- distill, inject, audit, cleanup |
 | **Skill (read)** | `skills/rlm-search/` -- query the ledger |
 | **Skill (Phase 1 search)** | `rlm-factory:rlm-search` |
@@ -116,7 +116,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/vector-db/` |
+| **Plugin** | `.agents/skills/` (vector-db-search, vector-db-ingest, vector-db-launch, vector-db-init) |
 | **Skill** | `skills/vector-db-agent/` -- ingest, query, operations |
 | **Skill (Phase 2 search)** | `vector-db:vector-db-search` |
 | **Skill (ingest files)** | `vector-db:vector-db-ingest` |
@@ -128,7 +128,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/obsidian-integration/` |
+| **Plugin** | `.agents/skills/` (obsidian-vault-crud, obsidian-init, obsidian-canvas-architect, obsidian-graph-traversal) |
 | **Skill: vault setup** | `skills/obsidian-init/` -- prerequisites, `.obsidian/` config, exclusion filters |
 | **Skill: read/write notes** | `obsidian-integration:obsidian-vault-crud` -- atomic create/read/update/append |
 | **Skill: CRUD operations** | `obsidian-integration:obsidian-vault-crud` |

--- a/.agents/skills/mine-plugins/SKILL.md
+++ b/.agents/skills/mine-plugins/SKILL.md
@@ -102,7 +102,7 @@ Invoke the `synthesize-learnings` skill to produce targeted recommendations for:
 1. `agent-scaffolders` — template and scaffold improvements
 2. `agent-skill-open-specifications` — standards and spec updates
 3. `agent-plugin-analyzer` — self-improvement of this analyzer
-4. Domain plugins (e.g., `legacy system`) — transferable patterns for legacy code analysis
+4. Domain plugins (e.g., `oracle-legacy-system-analysis`) — transferable patterns for legacy code analysis
 
 ### Step 6: Deliver Report
 

--- a/.agents/skills/path-reference-auditor/SKILL.md
+++ b/.agents/skills/path-reference-auditor/SKILL.md
@@ -31,7 +31,7 @@ Complete path reference audit system for plugins and skills. Ensures all `./file
 ## What This Skill Does
 
 Validates that file references in plugins and skills are:
-- **Skill-local**: References in `plugins/X/skills/Y/` stay within `Y/`
+- **Skill-local**: References in `.agents/skills/Y/` stay within `Y/`
 - **Plugin-local**: References in `plugins/X/` (root level) stay within `X/`
 - **Resolvable**: All `./` paths point to actual files (or symlinks)
 
@@ -90,7 +90,7 @@ python3 scripts/check_skill_boundaries.py temp/inventory.json --skill adr-manage
 
 Example violation:
 ```
-FILE: plugins/adr-manager/skills/adr-management/SKILL.md:45
+FILE: .agents/skills/adr-management/SKILL.md:45
   REF: ../../templates/adr-template.md  ❌ OUTSIDE SKILL
   FIX: Create symlink inside skill
 ```
@@ -198,7 +198,7 @@ cp -r plugins/agent-plugin-analyzer /path/to/target/plugins/
 
 Then run from project root:
 ```bash
-python3 plugins/agent-plugin-analyzer/skills/path-reference-auditor/./path_reference_auditor.py --project . --phase scan
+python3 .agents/skills/path-reference-auditor/./path_reference_auditor.py --project . --phase scan
 ```
 
 ---
@@ -206,15 +206,15 @@ python3 plugins/agent-plugin-analyzer/skills/path-reference-auditor/./path_refer
 ## Core Principles
 
 ### Skill Boundary Rule
-All file references **inside** `plugins/X/skills/Y/` must resolve **within** `Y/`.
+All file references **inside** `.agents/skills/Y/` must resolve **within** `Y/`.
 
 **Valid:**
-- `./scripts/tool.py` → `plugins/X/skills/Y/scripts/tool.py` ✅
-- `./references/guide.md` → `plugins/X/skills/Y/references/guide.md` ✅
+- `./scripts/tool.py` → `.agents/skills/Y/scripts/tool.py` ✅
+- `./references/guide.md` → `.agents/skills/Y/references/guide.md` ✅
 
 **Invalid:**
 - `../../templates/file.md` → `plugins/X/templates/file.md` (outside skill) ❌
-- `../other-skill/file.md` → `plugins/X/skills/other-skill/file.md` (sibling skill) ❌
+- `../other-skill/file.md` → `.agents/skills/other-skill/file.md` (sibling skill) ❌
 
 **Fix:** Create symlink inside the skill:
 ```bash
@@ -227,7 +227,7 @@ All file references **inside** `plugins/X/` (root level, non-skill files) must r
 
 **Valid:**
 - `./commands/file.md` → `plugins/X/commands/file.md` ✅
-- `./skills/Y/SKILL.md` → `plugins/X/skills/Y/SKILL.md` ✅
+- `./skills/Y/SKILL.md` → `.agents/skills/Y/SKILL.md` ✅
 
 **Invalid:**
 - `../other-plugin/file.md` → `plugins/other-plugin/file.md` (sibling plugin) ❌

--- a/.agents/skills/rlm-factory-rlm-cleanup/SKILL.md
+++ b/.agents/skills/rlm-factory-rlm-cleanup/SKILL.md
@@ -27,7 +27,7 @@ its file no longer exists or has moved. Running this regularly keeps the ledger 
 
 ## Prerequisites
 
-**Profile not configured?** Run `rlm-init` skill first: `plugins/rlm-factory/skills/rlm-init/SKILL.md`
+**Profile not configured?** Run `rlm-init` skill first: `.agents/skills/rlm-init/SKILL.md`
 
 ## When to Run
 

--- a/.agents/skills/rlm-factory-rlm-distill/SKILL.md
+++ b/.agents/skills/rlm-factory-rlm-distill/SKILL.md
@@ -37,7 +37,7 @@ summary, and inject it into the ledger via `inject_summary.py`.
 
 **First-time setup or missing profile?** Run the `rlm-init` skill first:
 ```bash
-# See: plugins/rlm-factory/skills/rlm-init/SKILL.md
+# See: .agents/skills/rlm-init/SKILL.md
 # Creates rlm_profiles.json, manifest, and empty cache
 ```
 
@@ -62,7 +62,7 @@ and what are its key components/functions?"* in one dense sentence.
 ```bash
 python3 ./scripts/inject_summary.py \
   --profile project \
-  --file plugins/example/skills/my-skill/SKILL.md \
+  --file .agents/skills/my-skill/SKILL.md \
   --summary "Provides atomic vault CRUD operations for Obsidian notes using POSIX rename and fcntl.flock."
 ```
 
@@ -99,7 +99,7 @@ python3 ./scripts/swarm_run.py \
   --resume --workers 5
 ```
 
-See `plugins/agent-loops/skills/agent-swarm/SKILL.md` for full swarm configuration options.
+See `.agents/skills/agent-swarm/SKILL.md` for full swarm configuration options.
 
 ## Quality Standard for Summaries
 

--- a/.agents/skills/synthesize-learnings/SKILL.md
+++ b/.agents/skills/synthesize-learnings/SKILL.md
@@ -56,7 +56,7 @@ Improvements to this analyzer plugin itself.
 - Framework gaps — phases that need refinement
 - New anti-patterns to add to the detection checklist
 
-### Target 4: Domain Plugins (e.g., `legacy system`)
+### Target 4: Domain Plugins (e.g., `oracle-legacy-system-analysis`)
 Improvements to the primary domain plugins in this repository — especially the legacy Oracle Forms/DB analysis plugins.
 
 **What to look for:**

--- a/.agents/skills/synthesize-learnings/acceptance-criteria.md
+++ b/.agents/skills/synthesize-learnings/acceptance-criteria.md
@@ -3,7 +3,7 @@
 To ensure `synthesize-learnings` correctly closes the virtuous cycle loop, it must pass the following criteria when evaluated against a raw plugin analysis report.
 
 ## 1. Actionable Recommendations
-Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `legacy system`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
+Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `oracle-legacy-system-analysis`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
 
 ## 2. Proper Categorization
 Extracted patterns must be correctly mapped using the defined categories (Structural, Content, Execution, Integration, Quality, Meta, Domain).

--- a/.agents/skills/synthesize-learnings/references/acceptance-criteria.md
+++ b/.agents/skills/synthesize-learnings/references/acceptance-criteria.md
@@ -3,7 +3,7 @@
 To ensure `synthesize-learnings` correctly closes the virtuous cycle loop, it must pass the following criteria when evaluated against a raw plugin analysis report.
 
 ## 1. Actionable Recommendations
-Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `legacy system`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
+Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `oracle-legacy-system-analysis`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
 
 ## 2. Proper Categorization
 Extracted patterns must be correctly mapped using the defined categories (Structural, Content, Execution, Integration, Quality, Meta, Domain).

--- a/.agents/skills/synthesize-learnings/references/improvement-mapping.md
+++ b/.agents/skills/synthesize-learnings/references/improvement-mapping.md
@@ -33,7 +33,7 @@ Changes here improve our ability to analyze future plugins.
 | **Any Pattern** | `skills/analyze-plugin/references/pattern-catalog.md` | Register the new pattern so it is recognized in future scans. |
 | **Analysis Gap** | `skills/analyze-plugin/SKILL.md` | Add new checks to Phase 3 (Content Analysis). |
 
-## Target 4: Domain Plugins (legacy system)
+## Target 4: Domain Plugins (oracle-legacy-system-analysis)
 
 Changes here apply knowledge-work patterns to our primary engineering domain.
 

--- a/.agents/skills/task-agent/SKILL.md
+++ b/.agents/skills/task-agent/SKILL.md
@@ -38,7 +38,7 @@ python3 .agents/skills/task-agent/scripts/task_manager.py <command>
 ```
 
 **Do NOT use** `./task_manager.py` (relative to script dir — breaks from project root) or
-`plugins/task-manager/skills/task-agent/scripts/task_manager.py` (plugin source — not the
+`.agents/skills/task-agent/scripts/task_manager.py` (plugin source — not the
 installed copy, may be out of sync if bridge-plugin was run).
 
 ## Architectural Constraints (Kanban Sovereignty)

--- a/.agents/skills/tool-inventory/SKILL.md
+++ b/.agents/skills/tool-inventory/SKILL.md
@@ -31,7 +31,7 @@ This skill combines **Tool Discovery** (finding tools) and **Inventory Managemen
 
 | Script | Role | Dependencies |
 |:---|:---|:---|
-| `manage_tool_inventory.py` | **The Registry** — CRUD on plugins/tool_inventory.json | Triggers RLM distllation |
+| `manage_tool_inventory.py` | **The Registry** - CRUD on `tool_inventory.json` | Triggers RLM distillation |
 | `audit_plugins.py` | **The Auditor** — Verify inventory consistency | Filesystem check |
 
 > **Note**: For Semantic Search, Distillation, Cache Querying, and Cleanup, you **MUST** use the respective scripts inside the `rlm-curator` skill provided by the `rlm-factory` plugin.
@@ -47,7 +47,7 @@ The ecosystem contains hundreds of scripts. You are fundamentally incapable of h
 **ALWAYS** use the semantic query tools hooked up to `ChromaDB` (`tool_chroma.py search`) to discover tooling.
 
 ### ❌ WRONG: Manual Registry Edits
-**NEVER** manually edit `plugins/tool_inventory.json` using raw standard tools. 
+**NEVER** manually edit `tool_inventory.json` using raw standard tools.
 
 ### ✅ CORRECT: Database CRUD
 **ALWAYS** use `manage_tool_inventory.py` for registry CRUD operations. Only the CLI is permissioned to alter the inventory state safely.
@@ -64,7 +64,7 @@ When executing a search in `ChromaDB`:
 
 ### 1. Register New Tools
 ```bash
-python3 .agents/skills/tool-inventory/scripts/manage_tool_inventory.py add --path plugins/new_script_example.txt
+python3 .agents/skills/tool-inventory/scripts/manage_tool_inventory.py add --path scripts/new_script_example.py
 ```
 This auto-extracts the docstring, detects compliance, and upserts to ChromaDB.
 

--- a/.agents/skills/vector-db-search/SKILL.md
+++ b/.agents/skills/vector-db-search/SKILL.md
@@ -48,7 +48,7 @@ returns insufficient results.
 curl -sf http://127.0.0.1:8110/api/v1/heartbeat
 ```
 
-If connection refused: run `vector-db-launch` skill (`plugins/vector-db/skills/vector-db-launch/SKILL.md`).
+If connection refused: run `vector-db-launch` skill (`.agents/skills/vector-db-launch/SKILL.md`).
 For first-time setup: run `vector-db-init` skill (`scripts/init.py`).
 
 ### 2. Select Profile and Search

--- a/.agents/workflows/agent-plugin-analyzer_mine-plugins.md
+++ b/.agents/workflows/agent-plugin-analyzer_mine-plugins.md
@@ -76,7 +76,7 @@ Invoke the `synthesize-learnings` skill to produce targeted recommendations for:
 1. `agent-scaffolders` — template and scaffold improvements
 2. `agent-skill-open-specifications` — standards and spec updates
 3. `agent-plugin-analyzer` — self-improvement of this analyzer
-4. Domain plugins (e.g., `legacy system`) — transferable patterns for legacy code analysis
+4. Domain plugins (e.g., `oracle-legacy-system-analysis`) — transferable patterns for legacy code analysis
 
 ### Step 6: Deliver Report
 

--- a/.agents/workflows/context-bundler_context-bundling.md
+++ b/.agents/workflows/context-bundler_context-bundling.md
@@ -80,7 +80,7 @@ Instead of:
 ```json
 { "path": "plugins/agent-agentic-os/README.md", "note": "..." },
 { "path": "plugins/agent-agentic-os/SUMMARY.md", "note": "..." },
-{ "path": "plugins/agent-agentic-os/skills/agentic-os-guide/SKILL.md", "note": "..." },
+{ "path": ".agents/skills/agentic-os-guide/SKILL.md", "note": "..." },
 ...
 ```
 

--- a/.agents/workflows/memory-management_memory-management.md
+++ b/.agents/workflows/memory-management_memory-management.md
@@ -103,7 +103,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/rlm-factory/` |
+| **Plugin** | `.agents/skills/` (rlm-curator, rlm-search, rlm-init, rlm-distill-agent) |
 | **Skill (write)** | `skills/rlm-curator/` -- distill, inject, audit, cleanup |
 | **Skill (read)** | `skills/rlm-search/` -- query the ledger |
 | **Skill (Phase 1 search)** | `rlm-factory:rlm-search` |
@@ -116,7 +116,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/vector-db/` |
+| **Plugin** | `.agents/skills/` (vector-db-search, vector-db-ingest, vector-db-launch, vector-db-init) |
 | **Skill** | `skills/vector-db-agent/` -- ingest, query, operations |
 | **Skill (Phase 2 search)** | `vector-db:vector-db-search` |
 | **Skill (ingest files)** | `vector-db:vector-db-ingest` |
@@ -128,7 +128,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/obsidian-integration/` |
+| **Plugin** | `.agents/skills/` (obsidian-vault-crud, obsidian-init, obsidian-canvas-architect, obsidian-graph-traversal) |
 | **Skill: vault setup** | `skills/obsidian-init/` -- prerequisites, `.obsidian/` config, exclusion filters |
 | **Skill: read/write notes** | `obsidian-integration:obsidian-vault-crud` -- atomic create/read/update/append |
 | **Skill: CRUD operations** | `obsidian-integration:obsidian-vault-crud` |

--- a/.agents/workflows/vector-db_vector-db-search.md
+++ b/.agents/workflows/vector-db_vector-db-search.md
@@ -48,7 +48,7 @@ returns insufficient results.
 curl -sf http://127.0.0.1:8110/api/v1/heartbeat
 ```
 
-If connection refused: run `vector-db-launch` skill (`plugins/vector-db/skills/vector-db-launch/SKILL.md`).
+If connection refused: run `vector-db-launch` skill (`.agents/skills/vector-db-launch/SKILL.md`).
 For first-time setup: run `vector-db-init` skill (`scripts/init.py`).
 
 ### 2. Select Profile and Search

--- a/plugins/agent-agentic-os/skills/concurrent-agent-loop/SKILL.md
+++ b/plugins/agent-agentic-os/skills/concurrent-agent-loop/SKILL.md
@@ -91,8 +91,8 @@ Use Standard Cycle only when the north star is regressing or explicitly requeste
    | `memory.md` | LAB `context/` | Standard Cycle -- promoted L3 facts via session-memory-manager. |
    | `HOW-TO-RESTART.md` | UPSTREAM `temp/agent-agentic-os-review/` | Every cycle -- reflect state changes. |
    | `tasks/backlog/NNNN-[slug].md` | UPSTREAM `tasks/backlog/` | When M/L-class issue is observed. |
-   | `references/backlog.md` | UPSTREAM `plugins/agent-agentic-os/references/` | When any issue is observed (S/M/L). |
-   | **`SKILL.md` (this file)** | UPSTREAM `plugins/agent-agentic-os/skills/concurrent-agent-loop/` | **When applicable** -- if the loop produces a confirmed protocol improvement (step unclear, gap found, new requirement), ORCHESTRATOR updates this file before closing the cycle. Self-improvement of the loop protocol is a first-class output of every loop. |
+   | `references/backlog.md` | UPSTREAM `references/` | When any issue is observed (S/M/L). |
+   | **`SKILL.md` (this file)** | UPSTREAM `.agents/skills/concurrent-agent-loop/` | **When applicable** -- if the loop produces a confirmed protocol improvement (step unclear, gap found, new requirement), ORCHESTRATOR updates this file before closing the cycle. Self-improvement of the loop protocol is a first-class output of every loop. |
 
    A cycle that produces a protocol fix but does not update this SKILL.md has not fully closed.
 

--- a/plugins/agent-agentic-os/skills/loop-progress-report/SKILL.md
+++ b/plugins/agent-agentic-os/skills/loop-progress-report/SKILL.md
@@ -71,7 +71,7 @@ This skill produces the same chart for agentic-os and exploration-cycle-plugin i
 | Source | Content |
 |--------|---------|
 | `context/memory/improvement-ledger.md` | Eval score progression (Section 1), survey-to-action trace (Section 2), north star metric (Section 3) |
-| `plugins/*/skills/*/evals/results.tsv` | Per-skill detailed eval score history (supplement to ledger) |
+| `.agents/skills/*/evals/results.tsv` | Per-skill detailed eval score history (supplement to ledger) |
 
 The improvement ledger is the primary source. It is written at every loop close (Stage 4.7
 of concurrent-agent-loop). See `references/improvement-ledger-spec.md` for the format.
@@ -108,7 +108,7 @@ Do not run the report script on an empty ledger — it will produce an empty cha
 ### Phase 2: Run the report
 
 ```bash
-PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-$(pwd)/plugins/agent-agentic-os}"
+PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-$(pwd)/.agents/skills/agent-agentic-os}"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 python3 "${PLUGIN_DIR}/skills/loop-progress-report/scripts/generate_report.py" \

--- a/plugins/agent-plugin-analyzer/commands/mine-plugins.md
+++ b/plugins/agent-plugin-analyzer/commands/mine-plugins.md
@@ -76,7 +76,7 @@ Invoke the `synthesize-learnings` skill to produce targeted recommendations for:
 1. `agent-scaffolders` — template and scaffold improvements
 2. `agent-skill-open-specifications` — standards and spec updates
 3. `agent-plugin-analyzer` — self-improvement of this analyzer
-4. Domain plugins (e.g., `legacy system`) — transferable patterns for legacy code analysis
+4. Domain plugins (e.g., `oracle-legacy-system-analysis`) — transferable patterns for legacy code analysis
 
 ### Step 6: Deliver Report
 

--- a/plugins/agent-plugin-analyzer/references/improvement-mapping.md
+++ b/plugins/agent-plugin-analyzer/references/improvement-mapping.md
@@ -33,7 +33,7 @@ Changes here improve our ability to analyze future plugins.
 | **Any Pattern** | `skills/analyze-plugin/references/pattern-catalog.md` | Register the new pattern so it is recognized in future scans. |
 | **Analysis Gap** | `skills/analyze-plugin/SKILL.md` | Add new checks to Phase 3 (Content Analysis). |
 
-## Target 4: Domain Plugins (legacy system)
+## Target 4: Domain Plugins (oracle-legacy-system-analysis)
 
 Changes here apply knowledge-work patterns to our primary engineering domain.
 

--- a/plugins/agent-plugin-analyzer/skills/audit-plugin-l5/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/audit-plugin-l5/SKILL.md
@@ -23,7 +23,7 @@ See `../../requirements.txt` for the dependency lockfile (currently empty — st
 This skill abstracts the execution of the L5 Enterprise Red Team Auditor. By using this skill, you trigger an uncompromising architecture and security review against the 39-point pattern matrix.
 
 ## Discovery Phase
-Before executing this skill, ensure you know the exact path or name of the plugin you wish to audit (e.g., `plugins/legacy system/xml-to-markdown`).
+Before executing this skill, ensure you know the exact path or name of the plugin you wish to audit (e.g., `plugins/oracle-legacy-system-analysis/xml-to-markdown`).
 
 ## Execution
 This skill delegates immediately to the `l5-red-team-auditor` sub-agent.

--- a/plugins/agent-plugin-analyzer/skills/mine-plugins/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/mine-plugins/SKILL.md
@@ -102,7 +102,7 @@ Invoke the `synthesize-learnings` skill to produce targeted recommendations for:
 1. `agent-scaffolders` — template and scaffold improvements
 2. `agent-skill-open-specifications` — standards and spec updates
 3. `agent-plugin-analyzer` — self-improvement of this analyzer
-4. Domain plugins (e.g., `legacy system`) — transferable patterns for legacy code analysis
+4. Domain plugins (e.g., `oracle-legacy-system-analysis`) — transferable patterns for legacy code analysis
 
 ### Step 6: Deliver Report
 

--- a/plugins/agent-plugin-analyzer/skills/path-reference-auditor/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/path-reference-auditor/SKILL.md
@@ -31,7 +31,7 @@ Complete path reference audit system for plugins and skills. Ensures all `./file
 ## What This Skill Does
 
 Validates that file references in plugins and skills are:
-- **Skill-local**: References in `plugins/X/skills/Y/` stay within `Y/`
+- **Skill-local**: References in `.agents/skills/Y/` stay within `Y/`
 - **Plugin-local**: References in `plugins/X/` (root level) stay within `X/`
 - **Resolvable**: All `./` paths point to actual files (or symlinks)
 
@@ -90,7 +90,7 @@ python3 scripts/check_skill_boundaries.py temp/inventory.json --skill adr-manage
 
 Example violation:
 ```
-FILE: plugins/adr-manager/skills/adr-management/SKILL.md:45
+FILE: .agents/skills/adr-management/SKILL.md:45
   REF: ../../templates/adr-template.md  ❌ OUTSIDE SKILL
   FIX: Create symlink inside skill
 ```
@@ -198,7 +198,7 @@ cp -r plugins/agent-plugin-analyzer /path/to/target/plugins/
 
 Then run from project root:
 ```bash
-python3 plugins/agent-plugin-analyzer/skills/path-reference-auditor/./path_reference_auditor.py --project . --phase scan
+python3 .agents/skills/path-reference-auditor/./path_reference_auditor.py --project . --phase scan
 ```
 
 ---
@@ -206,15 +206,15 @@ python3 plugins/agent-plugin-analyzer/skills/path-reference-auditor/./path_refer
 ## Core Principles
 
 ### Skill Boundary Rule
-All file references **inside** `plugins/X/skills/Y/` must resolve **within** `Y/`.
+All file references **inside** `.agents/skills/Y/` must resolve **within** `Y/`.
 
 **Valid:**
-- `./scripts/tool.py` → `plugins/X/skills/Y/scripts/tool.py` ✅
-- `./references/guide.md` → `plugins/X/skills/Y/references/guide.md` ✅
+- `./scripts/tool.py` → `.agents/skills/Y/scripts/tool.py` ✅
+- `./references/guide.md` → `.agents/skills/Y/references/guide.md` ✅
 
 **Invalid:**
 - `../../templates/file.md` → `plugins/X/templates/file.md` (outside skill) ❌
-- `../other-skill/file.md` → `plugins/X/skills/other-skill/file.md` (sibling skill) ❌
+- `../other-skill/file.md` → `.agents/skills/other-skill/file.md` (sibling skill) ❌
 
 **Fix:** Create symlink inside the skill:
 ```bash
@@ -227,7 +227,7 @@ All file references **inside** `plugins/X/` (root level, non-skill files) must r
 
 **Valid:**
 - `./commands/file.md` → `plugins/X/commands/file.md` ✅
-- `./skills/Y/SKILL.md` → `plugins/X/skills/Y/SKILL.md` ✅
+- `./skills/Y/SKILL.md` → `.agents/skills/Y/SKILL.md` ✅
 
 **Invalid:**
 - `../other-plugin/file.md` → `plugins/other-plugin/file.md` (sibling plugin) ❌

--- a/plugins/agent-plugin-analyzer/skills/synthesize-learnings/SKILL.md
+++ b/plugins/agent-plugin-analyzer/skills/synthesize-learnings/SKILL.md
@@ -56,7 +56,7 @@ Improvements to this analyzer plugin itself.
 - Framework gaps — phases that need refinement
 - New anti-patterns to add to the detection checklist
 
-### Target 4: Domain Plugins (e.g., `legacy system`)
+### Target 4: Domain Plugins (e.g., `oracle-legacy-system-analysis`)
 Improvements to the primary domain plugins in this repository — especially the legacy Oracle Forms/DB analysis plugins.
 
 **What to look for:**

--- a/plugins/agent-plugin-analyzer/skills/synthesize-learnings/acceptance-criteria.md
+++ b/plugins/agent-plugin-analyzer/skills/synthesize-learnings/acceptance-criteria.md
@@ -3,7 +3,7 @@
 To ensure `synthesize-learnings` correctly closes the virtuous cycle loop, it must pass the following criteria when evaluated against a raw plugin analysis report.
 
 ## 1. Actionable Recommendations
-Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `legacy system`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
+Every recommendation generated must specify a direct, concrete change to be made to one of the four targets (`agent-scaffolders`, `agent-skill-open-specifications`, `agent-plugin-analyzer`, or `oracle-legacy-system-analysis`). Recommendations must be testable (e.g., "Add the ~category connector abstraction to the create-skill template").
 
 ## 2. Proper Categorization
 Extracted patterns must be correctly mapped using the defined categories (Structural, Content, Execution, Integration, Quality, Meta, Domain).

--- a/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/SKILL.md
+++ b/plugins/agent-skill-open-specifications/skills/ecosystem-authoritative-sources/SKILL.md
@@ -43,7 +43,7 @@ are community conventions built on top of these primitives (not Anthropic-offici
 
 For bootstrapping Agentic OS in a project, use the `agentic-os-init` skill:
 ```
-plugins/agent-agentic-os/skills/agentic-os-init/SKILL.md
+.agents/skills/agentic-os-init/SKILL.md
 ```
 
 # The Library

--- a/plugins/claude-cli/skills/claude-cli-agent/SKILL.md
+++ b/plugins/claude-cli/skills/claude-cli-agent/SKILL.md
@@ -79,7 +79,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/plugins/coding-conventions/skills/coding-conventions-agent/SKILL.md
+++ b/plugins/coding-conventions/skills/coding-conventions-agent/SKILL.md
@@ -30,12 +30,12 @@ You enforce coding conventions and documentation standards for all code in the p
 3. **Type hints** — all Python function signatures use type annotations
 4. **Naming** — `snake_case` (Python), `camelCase` (JS/TS), `PascalCase` (C# public)
 5. **Refactor threshold** — 50+ lines or 3+ nesting levels → extract helpers
-6. **Tool registration** — all `plugins/` scripts registered in `plugins/tool_inventory.json`
+6. **Tool registration** - all project scripts registered via the `tool-inventory` skill
 7. **Manifest schema** — use simple `{title, description, files}` format (ADR 097)
 
 ## 📂 Header Templates
-- **Python**: `plugins/templates/python-tool-header-template.py`
-- **JS/TS**: `plugins/templates/js-tool-header-template.js`
+- **Python**: `./scripts/python-tool-header-template.py` (in this skill's scripts/)
+- **JS/TS**: `./scripts/js-tool-header-template.js` (in this skill's scripts/)
 
 ## 📝 File Headers
 
@@ -149,11 +149,11 @@ module/
 
 ## 🛠️ Tool Inventory Integration
 
-All Python scripts in `plugins/` **must** be registered in `plugins/tool_inventory.json`.
+All project scripts **must** be registered in `tool_inventory.json` (tracked at project root).
 
 After creating or modifying a tool, trigger the `tool-inventory` skill to register the script and audit coverage.
 
 ### Pre-Commit Checklist
 - [ ] File has proper header
-- [ ] Script registered in `plugins/tool_inventory.json` (via `tool-inventory` skill)
+- [ ] Script registered in `tool_inventory.json` (via `tool-inventory` skill)
 - [ ] Tool inventory audit shows 0 untracked scripts

--- a/plugins/context-bundler/skills/context-bundling/SKILL.md
+++ b/plugins/context-bundler/skills/context-bundling/SKILL.md
@@ -80,7 +80,7 @@ Instead of:
 ```json
 { "path": "plugins/agent-agentic-os/README.md", "note": "..." },
 { "path": "plugins/agent-agentic-os/SUMMARY.md", "note": "..." },
-{ "path": "plugins/agent-agentic-os/skills/agentic-os-guide/SKILL.md", "note": "..." },
+{ "path": ".agents/skills/agentic-os-guide/SKILL.md", "note": "..." },
 ...
 ```
 

--- a/plugins/copilot-cli/skills/copilot-cli-agent/SKILL.md
+++ b/plugins/copilot-cli/skills/copilot-cli-agent/SKILL.md
@@ -136,7 +136,7 @@ For benchmark loops that call Copilot as the improvement backend, apply the same
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/plugins/exploration-cycle-plugin/agents/exploration-cycle-orchestrator-agent.md
+++ b/plugins/exploration-cycle-plugin/agents/exploration-cycle-orchestrator-agent.md
@@ -71,14 +71,14 @@ The requirements-doc-agent runs as a cheap Copilot CLI sub-agent. Call it once p
 ```bash
 # Pass 1: Problem framing
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, and goals." \
   --output exploration/captures/problem-framing.md
 
 # Pass 2: Business requirements
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, constraints." \
   --output exploration/captures/brd-draft.md
@@ -93,7 +93,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 # Pass 3: User stories
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set." \
   --output exploration/captures/user-stories-draft.md
@@ -106,28 +106,28 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 
 # Pass 4: Issues and opportunities (optional)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
 
 # Prototype observations (after prototype session)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Capture implied requirements, assumptions, and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md
 
 # Business Rule Audit (Logic Drift detection)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md exploration/captures/prototype-notes.md \
   --instruction "Audit the prototype behavior against the business rules. Detect logic drift." \
   --output exploration/captures/audit-findings.md
 
 # Synthesis for handoff
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/*.md \
   --instruction "Synthesize all captures into a handoff package." \
   --output exploration/handoff/exploration-handoff.md
@@ -135,21 +135,21 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: only if spec-kitty plugin is present ---------------------
 # Phase 5a: pre-draft spec.md (staging only)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft spec.md from this handoff. Mark gaps with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Phase 5b: pre-draft plan.md
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft plan.md with phases and WP hints. Mark gaps." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Phase 5c: WP tasks outline
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate WP outline. Stubs only." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -157,7 +157,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 # --- OPTIONAL: re-entry from spec-kitty engineering cycle ---------------
 # Triggered when spec-kitty cycle uncovers unresolved ambiguity (cycling back)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Draft a session brief for a new cycle." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md
+++ b/plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI with all capture documents piped as input:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \

--- a/plugins/exploration-cycle-plugin/agents/planning-doc-agent.md
+++ b/plugins/exploration-cycle-plugin/agents/planning-doc-agent.md
@@ -44,7 +44,7 @@ Pre-drafts `spec.md` from the handoff package. Output goes to staging — not di
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this exploration handoff. Follow Spec-Kitty spec format. Mark any gap with [NEEDS HUMAN INPUT]. Output to staging only." \
   --output exploration/planning-drafts/spec-draft.md
@@ -56,7 +56,7 @@ Pre-drafts `plan.md` with high-level phases and work package hints from the hand
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
@@ -68,7 +68,7 @@ Generates a first-pass work package outline (WP stubs) from the spec and plan dr
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline from these drafts. Use WP-XX format. Stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -80,7 +80,7 @@ When the spec-kitty engineering cycle encounters unresolved ambiguity, use this 
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context "" \
   --instruction "CONTEXT: [describe the ambiguity]. Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type (spike / brownfield). Draft a session brief." \
   --output exploration/session-brief-reentry-$(date +%Y%m%d).md

--- a/plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md
+++ b/plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md
@@ -21,7 +21,7 @@ You are invoked via CLI after a prototype session. The piped input is the curren
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --instruction "Mode: prototype-observations. Capture implied requirements and edge cases from the prototype session." \
   --output exploration/captures/prototype-notes.md

--- a/plugins/exploration-cycle-plugin/skills/business-workflow-doc/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/business-workflow-doc/SKILL.md
@@ -32,7 +32,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 
 ```bash
 cat exploration/session-brief.md exploration/captures/brd-draft.md \
-  | copilot -p "$(cat plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md)" \
+  | copilot -p "$(cat .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md)" \
     "Mode: workflow-map. Generate a Mermaid flowchart diagram of the core business process described in this context. Use a flowchart TD layout. Label each step clearly. Include decision nodes for branches and validation gates." \
   > exploration/captures/workflow-map.md
 ```

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
@@ -102,7 +102,7 @@ Dispatch the requirements-doc-agent as a cheap CLI sub-agent. Each pass is focus
 ### Pass 1: Problem Framing
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md \
   --instruction "Mode: problem-framing. Capture the problem statement, user groups, goals, and initial scope hypotheses." \
   --output exploration/captures/problem-framing.md
@@ -111,7 +111,7 @@ python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
 ### Pass 2: Business Requirements
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md \
   --instruction "Mode: business-requirements. Extract functional requirements, business rules, and constraints." \
   --output exploration/captures/brd-draft.md
@@ -127,7 +127,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
   --output exploration/captures/workflow-map.md
 # Then fan out to agent to populate the Mermaid skeleton:
 # python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-#   --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+#   --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
 #   --context exploration/captures/workflow-map.md \
 #   --instruction "Mode: workflow-map. Fill in the Mermaid diagram with actual process steps from the captures." \
 #   --output exploration/captures/workflow-map.md
@@ -136,7 +136,7 @@ python3 .agents/skills/business-workflow-doc/scripts/generate_workflow.py \
 ### Pass 3: User Stories
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md \
   --instruction "Mode: user-stories. Generate an initial user story set from the requirements." \
   --output exploration/captures/user-stories-draft.md
@@ -156,7 +156,7 @@ python3 .agents/skills/user-story-capture/scripts/execute.py \
 ### Pass 4: Issues and Opportunities (optional)
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/requirements-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-requirements-doc-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md \
   --instruction "Mode: issues-and-opportunities. Extract issue themes, challenges, and opportunities." \
   --output exploration/captures/issues-opportunities.md
@@ -185,7 +185,7 @@ If exploration needs a runnable prototype to resolve ambiguity:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/prototype-companion-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-prototype-companion-agent/SKILL.md \
   --context exploration/session-brief.md exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md \
   --instruction "Mode: prototype-observations. Capture implied requirements, assumptions, and edge cases observed." \
@@ -200,7 +200,7 @@ Run after prototype observations are captured and before the Narrowing Gate. Thi
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/business-rule-audit-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-business-rule-audit-agent/SKILL.md \
   --context exploration/captures/brd-draft.md \
   --optional-context exploration/captures/prototype-notes.md \
   --instruction "Run a full business rule audit. Compare all BR-xxx rules in the BRD against the prototype observations (if present). Produce a structured report with a required ## Unresolved Drifts section. List every rule with no corresponding evidence. If no prototype-notes are present, flag all rules as unverified." \
@@ -243,7 +243,7 @@ Synthesize all captures into a single handoff package:
 
 ```bash
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/handoff-preparer-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-handoff-preparer-agent/SKILL.md \
   --context exploration/captures/problem-framing.md exploration/captures/brd-draft.md exploration/captures/user-stories-draft.md \
   --optional-context exploration/captures/issues-opportunities.md exploration/captures/prototype-notes.md exploration/captures/business-rule-audit.md \
   --instruction "Synthesize all exploration captures into a structured handoff package. If a business rule audit is present, include its Unresolved Drifts section as a top-level risk section." \
@@ -270,21 +270,21 @@ This phase uses the [`planning-doc-agent`](../../agents/planning-doc-agent.md) t
 ```bash
 # Mode 1: spec-draft
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: spec-draft. Pre-draft a spec.md from this handoff. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/spec-draft.md
 
 # Mode 2: plan-draft
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/handoff/exploration-handoff.md \
   --instruction "Mode: plan-draft. Pre-draft a plan.md with phases and WP hints. Mark any gap with [NEEDS HUMAN INPUT]." \
   --output exploration/planning-drafts/plan-draft.md
 
 # Mode 3: tasks-outline (reads the two drafts above)
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context exploration/planning-drafts/spec-draft.md exploration/planning-drafts/plan-draft.md \
   --instruction "Mode: tasks-outline. Generate a WP outline. WP-XX stubs only — do not fabricate scope." \
   --output exploration/planning-drafts/tasks-outline.md
@@ -308,7 +308,7 @@ echo "CONTEXT: [describe the blocking ambiguity or engineering question here]" >
 
 # Step 2: dispatch
 python3 .agents/skills/exploration-workflow/scripts/dispatch.py \
-  --agent plugins/exploration-cycle-plugin/agents/planning-doc-agent.md \
+  --agent .agents/skills/exploration-cycle-plugin-planning-doc-agent/SKILL.md \
   --context /tmp/reentry-context-$$.md \
   --instruction "Mode: re-entry-scope. Identify the exploration gap. Suggest exploration type. Draft a session brief." \
   --output "exploration/session-brief-reentry-$(date +%Y%m%d).md"

--- a/plugins/gemini-cli/skills/gemini-cli-agent/SKILL.md
+++ b/plugins/gemini-cli/skills/gemini-cli-agent/SKILL.md
@@ -76,7 +76,7 @@ When dispatching code-review, architecture, or security analysis, explicitly ins
 | Business | product-manager | Product strategy |
 | Specialization | api-documenter, documentation-expert | Technical writing |
 
-All personas in: `plugins/personas/`
+All personas are documented in the table above. Load the persona prompt file from your CLI plugin's `agents/` directory.
 
 ## 🔄 Recommended Audit Loop
 1. **Red Team** (Security Auditor) → find exploits

--- a/plugins/memory-management/skills/memory-management/SKILL.md
+++ b/plugins/memory-management/skills/memory-management/SKILL.md
@@ -103,7 +103,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/rlm-factory/` |
+| **Plugin** | `.agents/skills/` (rlm-curator, rlm-search, rlm-init, rlm-distill-agent) |
 | **Skill (write)** | `skills/rlm-curator/` -- distill, inject, audit, cleanup |
 | **Skill (read)** | `skills/rlm-search/` -- query the ledger |
 | **Skill (Phase 1 search)** | `rlm-factory:rlm-search` |
@@ -116,7 +116,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/vector-db/` |
+| **Plugin** | `.agents/skills/` (vector-db-search, vector-db-ingest, vector-db-launch, vector-db-init) |
 | **Skill** | `skills/vector-db-agent/` -- ingest, query, operations |
 | **Skill (Phase 2 search)** | `vector-db:vector-db-search` |
 | **Skill (ingest files)** | `vector-db:vector-db-ingest` |
@@ -128,7 +128,7 @@ rg "def query" ../../ --type py
 
 | Component | Value |
 |:----------|:------|
-| **Plugin** | `plugins/obsidian-integration/` |
+| **Plugin** | `.agents/skills/` (obsidian-vault-crud, obsidian-init, obsidian-canvas-architect, obsidian-graph-traversal) |
 | **Skill: vault setup** | `skills/obsidian-init/` -- prerequisites, `.obsidian/` config, exclusion filters |
 | **Skill: read/write notes** | `obsidian-integration:obsidian-vault-crud` -- atomic create/read/update/append |
 | **Skill: CRUD operations** | `obsidian-integration:obsidian-vault-crud` |

--- a/plugins/rlm-factory/agents/rlm-cleanup.md
+++ b/plugins/rlm-factory/agents/rlm-cleanup.md
@@ -27,7 +27,7 @@ its file no longer exists or has moved. Running this regularly keeps the ledger 
 
 ## Prerequisites
 
-**Profile not configured?** Run `rlm-init` skill first: `plugins/rlm-factory/skills/rlm-init/SKILL.md`
+**Profile not configured?** Run `rlm-init` skill first: `.agents/skills/rlm-init/SKILL.md`
 
 ## When to Run
 

--- a/plugins/rlm-factory/agents/rlm-distill.md
+++ b/plugins/rlm-factory/agents/rlm-distill.md
@@ -37,7 +37,7 @@ summary, and inject it into the ledger via `inject_summary.py`.
 
 **First-time setup or missing profile?** Run the `rlm-init` skill first:
 ```bash
-# See: plugins/rlm-factory/skills/rlm-init/SKILL.md
+# See: .agents/skills/rlm-init/SKILL.md
 # Creates rlm_profiles.json, manifest, and empty cache
 ```
 
@@ -62,7 +62,7 @@ and what are its key components/functions?"* in one dense sentence.
 ```bash
 python3 ./scripts/inject_summary.py \
   --profile project \
-  --file plugins/example/skills/my-skill/SKILL.md \
+  --file .agents/skills/my-skill/SKILL.md \
   --summary "Provides atomic vault CRUD operations for Obsidian notes using POSIX rename and fcntl.flock."
 ```
 
@@ -99,7 +99,7 @@ python3 ./scripts/swarm_run.py \
   --resume --workers 5
 ```
 
-See `plugins/agent-loops/skills/agent-swarm/SKILL.md` for full swarm configuration options.
+See `.agents/skills/agent-swarm/SKILL.md` for full swarm configuration options.
 
 ## Quality Standard for Summaries
 

--- a/plugins/task-manager/skills/task-agent/SKILL.md
+++ b/plugins/task-manager/skills/task-agent/SKILL.md
@@ -38,7 +38,7 @@ python3 .agents/skills/task-agent/scripts/task_manager.py <command>
 ```
 
 **Do NOT use** `./task_manager.py` (relative to script dir — breaks from project root) or
-`plugins/task-manager/skills/task-agent/scripts/task_manager.py` (plugin source — not the
+`.agents/skills/task-agent/scripts/task_manager.py` (plugin source — not the
 installed copy, may be out of sync if bridge-plugin was run).
 
 ## Architectural Constraints (Kanban Sovereignty)

--- a/plugins/tool-inventory/skills/tool-inventory/SKILL.md
+++ b/plugins/tool-inventory/skills/tool-inventory/SKILL.md
@@ -31,7 +31,7 @@ This skill combines **Tool Discovery** (finding tools) and **Inventory Managemen
 
 | Script | Role | Dependencies |
 |:---|:---|:---|
-| `manage_tool_inventory.py` | **The Registry** — CRUD on plugins/tool_inventory.json | Triggers RLM distllation |
+| `manage_tool_inventory.py` | **The Registry** - CRUD on `tool_inventory.json` | Triggers RLM distillation |
 | `audit_plugins.py` | **The Auditor** — Verify inventory consistency | Filesystem check |
 
 > **Note**: For Semantic Search, Distillation, Cache Querying, and Cleanup, you **MUST** use the respective scripts inside the `rlm-curator` skill provided by the `rlm-factory` plugin.
@@ -47,7 +47,7 @@ The ecosystem contains hundreds of scripts. You are fundamentally incapable of h
 **ALWAYS** use the semantic query tools hooked up to `ChromaDB` (`tool_chroma.py search`) to discover tooling.
 
 ### ❌ WRONG: Manual Registry Edits
-**NEVER** manually edit `plugins/tool_inventory.json` using raw standard tools. 
+**NEVER** manually edit `tool_inventory.json` using raw standard tools.
 
 ### ✅ CORRECT: Database CRUD
 **ALWAYS** use `manage_tool_inventory.py` for registry CRUD operations. Only the CLI is permissioned to alter the inventory state safely.
@@ -64,7 +64,7 @@ When executing a search in `ChromaDB`:
 
 ### 1. Register New Tools
 ```bash
-python3 .agents/skills/tool-inventory/scripts/manage_tool_inventory.py add --path plugins/new_script_example.txt
+python3 .agents/skills/tool-inventory/scripts/manage_tool_inventory.py add --path scripts/new_script_example.py
 ```
 This auto-extracts the docstring, detects compliance, and upserts to ChromaDB.
 

--- a/plugins/vector-db/skills/vector-db-search/SKILL.md
+++ b/plugins/vector-db/skills/vector-db-search/SKILL.md
@@ -48,7 +48,7 @@ returns insufficient results.
 curl -sf http://127.0.0.1:8110/api/v1/heartbeat
 ```
 
-If connection refused: run `vector-db-launch` skill (`plugins/vector-db/skills/vector-db-launch/SKILL.md`).
+If connection refused: run `vector-db-launch` skill (`.agents/skills/vector-db-launch/SKILL.md`).
 For first-time setup: run `vector-db-init` skill (`scripts/init.py`).
 
 ### 2. Select Profile and Search

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,147 +11,147 @@
       "sourceType": "local",
       "computedHash": "a8b17870659a793a77ba019eebdd3d5198d04c111498c8613cf3f975c0640907",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-03-27T16:49:53.492499Z"
+      "updatedAt": "2026-03-27T21:14:32.174749Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "26dc20f54e016582960fbb5a4298edc7317f439821b8cb7b0d100a1e877b2b80",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "agent-agentic-os-os-health-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "b741e7b098118904f38476b4d595254d4cade9f3b78cbeb04be7b92658815b11",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "agent-agentic-os-os-learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "dbcd39667b174675a56d27fef001ca2c3b1c4c8434f8b82ffe916bb48f059a13",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "agent-execution-disciplines-code-reviewer": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "b2f56d055034742a204e53f2dfebf00569be7594f05b98aab951f9b792076571",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "agent-loops-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "2173c3aaa0b519bac0a955d0c49fb1de1bcf61991c157a5984dc40fc462b968e",
       "installedAt": "2026-03-19T23:20:37.731809Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "agent-plugin-analyzer-l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "d957e7ea0dd26d32707fc459008bbb5a37ddbedd34187ddfee4286c6ac1d02f8",
       "installedAt": "2026-03-19T23:20:38.237081Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "agent-swarm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "32f35c37348e6b2fdfe0299801eaf1945fb6d6197da7eeabf09341c1abb4c093",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3ae6ae7113c4cab890fdf37b8a959fe19ba240057c11ea61d13c717b1ae21614",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "agentic-os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "81718eb570dca9c8fb0a79c276c1ecda5dc41c882d5134393ab5c7c1d971bd3c",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "analyze-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a3363bb44af835848ae346efaaec39680f79fc5056c27574e6c4b0735f12098a",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "39f029362c123add0bfed714ca00c51e673a66c534d3fac063a2c6d58a77559e",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "414b322f1e0a9295c551a6bac1b2918e6f9a6a380c3b5c72e9de3745c77efd3d",
+      "computedHash": "aa406be0ff6634939d1b3bc6743317e68d04ec61bec30635a1c4ded26413e54d",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "auto-update-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "",
+      "computedHash": "030750436b18e964a43fa51e1839e9b530bebd6d2f065f9e220d9dea00c2cf34",
       "installedAt": "2026-03-27T16:11:14.650371Z",
-      "updatedAt": "2026-03-27T16:54:47.092289Z"
+      "updatedAt": "2026-03-27T21:14:33.822069Z"
     },
     "bridge-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "",
+      "computedHash": "ea3fd02de2b658bb85a4c519ea56bd3a8e6f02b2490a3373af4d6c6d5af53404",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-27T16:54:47.092289Z"
+      "updatedAt": "2026-03-27T21:14:33.822069Z"
     },
     "business-requirements-capture": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "c41a29bc52074ffeea79b5942a1c8182bab6a6a7c727479e3bfddadc614a3bce",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "business-workflow-doc": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "911c2c159f88b83930258785bf519cce64310e408630246c6d914d6c3f77049d",
+      "computedHash": "9102bbcbecb275082e60ec0523c3e0554f508799ea627c2d0c991576f4ccf977",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "5715008afbb03eeba7a179471b691e1443245ba666e102220c3020f2d7acbfeb",
+      "computedHash": "f6daa1e319230c92f67dd365348a901ddd35bd8ab37888f9af8794a99ae08f17",
       "installedAt": "2026-03-23T19:00:37.067705Z",
-      "updatedAt": "2026-03-27T16:49:54.285335Z"
+      "updatedAt": "2026-03-27T21:14:33.034313Z"
     },
     "claude-cli-claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "c4ea00e82d897719600762c98b81dd7dd169d3f6a628db4ac6a3abc4eb20e841",
+      "computedHash": "d6b64c421f7284812305b494e509ba2e289ff40b14a33d05458baa99a5382c98",
       "installedAt": "2026-03-19T23:20:40.774857Z",
-      "updatedAt": "2026-03-27T16:49:54.285335Z"
+      "updatedAt": "2026-03-27T21:14:33.034313Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "7a87f81a56f0d2aad72c562a7506a09d3fc28a39e082f2613959114132909d2d",
+      "computedHash": "0664747689761e0baad3e3db0a2c5a35be956fa8043509f782e8152f23f18621",
       "installedAt": "2026-03-23T19:00:37.700984Z",
-      "updatedAt": "2026-03-27T16:49:54.341992Z"
+      "updatedAt": "2026-03-27T21:14:33.092246Z"
     },
     "coding-conventions-coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "da3befe375d58c5563dc7eec5fc04246bb723ecc1b6da7677f769f25956d6a13",
+      "computedHash": "d953debd16820239b199f2d80aa6407a1697a4ecaa90b05155d2e1daf5d7a6af",
       "installedAt": "2026-03-19T23:20:40.949622Z",
-      "updatedAt": "2026-03-27T16:49:54.341992Z"
+      "updatedAt": "2026-03-27T21:14:33.092246Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -161,86 +161,86 @@
     "concurrent-agent-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "9276f327233f759977458fcbc26a1d5d6e52441b74d2d6028bbf910506dd5961",
+      "computedHash": "e2a16e0744832d43083e5e5cd63e73b7dc01e2cbbdeafddebb454aba9fc257e3",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "e6a85a8c114e96e64741112ba9b4ecfb36e70fe8e3f7fcd1c5f0a1aa81437915",
+      "computedHash": "a6d7c76fc921cf6b52ba2d571ff7e4cde7c07a23e9c35bc992fd42b918000f83",
       "installedAt": "2026-03-23T19:00:38.312643Z",
-      "updatedAt": "2026-03-27T16:49:54.395113Z"
+      "updatedAt": "2026-03-27T21:14:33.145930Z"
     },
     "continuous-skill-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "326745f396946bbf65a74de81edbbcc9eb8cbfd1b8f3d3dffac6555700c5f9b4",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "convert-mermaid": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "cbff1045fd7e0e0abda2a7f2085ecc9c3b5c510c74898c20cd6e80b1af4e9090",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-03-27T16:49:54.927740Z"
+      "updatedAt": "2026-03-27T21:14:33.680507Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "0a201d9df475dd2409d54b04cfbe532f5964424da61374a151039126f73dec27",
+      "computedHash": "ce702f87f1b941c4e454046e25ca8bb20a6e9042fe6ae9aa2e0756cfdb73cd8e",
       "installedAt": "2026-03-23T19:00:38.954419Z",
-      "updatedAt": "2026-03-27T16:49:54.443879Z"
+      "updatedAt": "2026-03-27T21:14:33.202232Z"
     },
     "copilot-cli-copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "d4feec81be68928fad99987c01e81007ed2fe41977a3188a9696606ae8c992d5",
+      "computedHash": "7db8f962ebb8b3132b7b35de79dab03e3f94a77e48ee28ed134a558a41948ae2",
       "installedAt": "2026-03-19T23:20:41.317243Z",
-      "updatedAt": "2026-03-27T16:49:54.443879Z"
+      "updatedAt": "2026-03-27T21:14:33.202232Z"
     },
     "create-agentic-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "8d18802c6eb1db99bbdbf5bb0a4e4427cd5702c909d15e76f7d00762f0741d1c",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "96adb80f2376f65332e3328eece5b3a9b960b49503656ed7d155dca206ca0582",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3b671128764ddf6152a66e307b57d348bcf04cee905709b4324b08a13954271d",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "0df418c40a6babc406f9d5ba0dc91427a41b5dd28c778d0a1c18247d496523c4",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "61720df6436b84940086e15427cb023bb4a224217b62bb68a4fbe573b01c39b0",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "699a07f842a12b02b920afdaf6431b29c9523f3efde72062ee87f3043e1d22ea",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -252,70 +252,70 @@
       "sourceType": "local",
       "computedHash": "fd8ca39be810d569d2aad9d683fed03e940b5a316de3eb62e3afd76d827eb4e3",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "62684a8d15d3647bf8d09c7fa05cfaa98602f07d09f4099bf666a5689430b4b7",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3d2fa545f68c3044a89f4e441c9ec591a9317bb48208ce72bfa3b29d1207c7dc",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "4204cbd89e0e406f957d1b161a159b85315bc309bbbc73f7808af53457fc8ea1",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3223560464ab155617b30b9b0690b832dcb2a11063f2942a52d3913fa167d8a2",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "deferred": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "23f00344ee6e0889ef4bdae988237ecca0a5de2a59ba3ba37bf73bb5254ee30c",
+      "computedHash": "2cd08759d6b6db8f13ec0ccda621e7127a151e470190f4a5f344d330793f0b87",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "dependency-management": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "9055ed4b48f887a339c95eb31c66b77f2fd19d2c7ff0c758c84e2ad64d70a011",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-03-27T16:49:54.496444Z"
+      "updatedAt": "2026-03-27T21:14:33.251994Z"
     },
     "dual-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "45371648c437fe2e79ba413ea6ceac29acc81d19d1973f8bd2e524d89daa6a94",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "9f911d68af2b2fc258bdb31f445a81003c529e3c783b5caf9358b70c53a1175f",
+      "computedHash": "90623b10287d5714c518ff3314b38ea7fe2aed409cda36bf2b9e6e81f125dd94",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-03-27T16:49:54.239522Z"
+      "updatedAt": "2026-03-27T21:14:32.984885Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "4a224f2693e6a029d64aa3216759a4e669a1f3eeca0503f335c237b79d6c8135",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-03-27T16:49:54.239522Z"
+      "updatedAt": "2026-03-27T21:14:32.984885Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -327,119 +327,119 @@
       "sourceType": "local",
       "computedHash": "914c08b7cae47f7b39a4f86896fde95975a0a2ced63e2798f67a4aa43e95f774",
       "installedAt": "2026-03-23T19:00:39.705846Z",
-      "updatedAt": "2026-03-27T16:49:54.546608Z"
+      "updatedAt": "2026-03-27T21:14:33.301261Z"
     },
     "exploration-cycle-plugin-business-rule-audit-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "43c2d344b0da555bf32a54794e97e00874d8defe57e881ab2f9d17536c48630d",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-exploration-cycle-orchestrator-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "8d0c27800afb413f9d844f26d4e88e236e77799c5ebba978b08ce0ce3107532a",
+      "computedHash": "199e091c0353da901926759b039b328985ab0651adf15cd7c978f4a03514ba3a",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-exploration-loop-orchestrator": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "84d0b0682d145fc8d0e86b24641b9b5ff8c77bb9020cde061d5e86ec683140ba",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-handoff-preparer-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "a01e4e6210a332023d8fd478231d7abd9a482c23c5ada84ee828b8ab16b36041",
+      "computedHash": "f3a82673247431166cf6cb5e1fdf7c74e776cf0b942d542042ca813d1d98e174",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-intake-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "2d2db553c907ecc5c504e6268a8b0ee5d632e0b1c808bdbfb3e82c2de88a75a1",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-planning-doc-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "a1f4bf6c984e700272431c9b2b1323d223a574ae0f2980f54d25ab60caad763f",
+      "computedHash": "cde97174f76c375db13f8284aedf29e2b7b1808a3a62f219fb9102097f92fe21",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-problem-framing-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "c1912d1eaeb263bdb61116ff558a960d922eee55eeffdecff87c44cbb73ba625",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-prototype-companion-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "7733ff88f8ff5d76f3d5f84b01f7de382c011c511c19ae2320e5ff27c26da9fb",
+      "computedHash": "3f417cbbfdf796b4718d41135619508c19f9e95cc7b911a54975c24f8eee8fac",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-requirements-doc-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "356967d70e181b2f1a064fba5acf251f0fe18b06c9df3f5e8574339527eecace",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-cycle-plugin-requirements-scribe-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "9a72891206e6d7866b4851c05af861bb6f1bf881b0a934c0cfb18514f569d2dd",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-handoff": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "3372684bd31ae5cefdb00f4343b959ccd22f64b6af2d218543ece3a4896e885b",
+      "computedHash": "a5640ad085705d4a9d80bf26e3e2475d1a0837f642c8a9f38b474fe46364389f",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-optimizer": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "8a2e68ce83461bca5a031ab50762d37b4f2066c4b9f3b98b20db80d450f158ea",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "765e3fce5d4c1815093c4884a2c1694bfd138932ee7a4787693c1674029097f4",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-session-brief": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "a8f6a4b44509937008e8596d577029e190728a79c26be7e4d724d0ca26c857b5",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "exploration-workflow": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
-      "computedHash": "84dc34a34eeb609a7721c4ea3688e814b501a9300e2d3200247cace80888add3",
+      "computedHash": "e896051deb0b86388fd24a60d0576f48aa1b3e6fab95ecd483b110ee60598d0d",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "finishing-a-development-branch": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "037c56822411e8561df9d6025036a073b7352e9d76669f413649995c64c60dd5",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -449,191 +449,191 @@
     "gemini-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "a0fe43c6f8c037b045524938d150ebff4909491991dfbb18767ff1adc933e8dd",
+      "computedHash": "a00ae2632cc8002f026d9242468a65f623b2800094d0bcededff0ac74ddb2bb3",
       "installedAt": "2026-03-23T19:00:42.069557Z",
-      "updatedAt": "2026-03-27T16:49:54.674343Z"
+      "updatedAt": "2026-03-27T21:14:33.427249Z"
     },
     "gemini-cli-gemini-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "52b00bda0cf33ad52a54c96ac27b05e25db3da50c68ea07feb8a1df1429687a2",
+      "computedHash": "8008128392440ecf60adde1a1c0432c59aae386afc39881e0385655930e1167b",
       "installedAt": "2026-03-19T23:20:41.911092Z",
-      "updatedAt": "2026-03-27T16:49:54.674343Z"
+      "updatedAt": "2026-03-27T21:14:33.427249Z"
     },
     "hf-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "7ce97db376a278eb3b1bca8aee3e5698d672c6e221056ab489ef913442a6f227",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-03-27T16:49:54.724828Z"
+      "updatedAt": "2026-03-27T21:14:33.477116Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "938b759a928220ac7677a6f2e94a4cda5138d7402eb3346e6f4ca8201e072747",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-03-27T16:49:54.724828Z"
+      "updatedAt": "2026-03-27T21:14:33.477116Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "7c9fc4c12894bd65fdfc8ab54acfa1b41a6b6d2dc25686259538ea2e5797dc51",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-03-27T16:49:56.065250Z"
+      "updatedAt": "2026-03-27T21:14:34.711980Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "95f8b6fde329489380ca66dd12df76d2a65201ec746d72b15317e1cc94b08c07",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "cae43901b1d812592a39e029ac36be9820a9a454bfbf59b368f0cbbd35d988e3",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a374a25def483e89610fa2dcfa2327fc7cea5483ba23186ae8772124180bc017",
       "installedAt": "2026-03-23T19:00:43.095665Z",
-      "updatedAt": "2026-03-27T16:49:54.774536Z"
+      "updatedAt": "2026-03-27T21:14:33.531456Z"
     },
     "link-checker-link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "38d124c59106518cd1a6a69bc2f5f104309357a2426c22dba7d3ee2fccd78428",
       "installedAt": "2026-03-19T23:20:42.398817Z",
-      "updatedAt": "2026-03-27T16:49:54.774536Z"
+      "updatedAt": "2026-03-27T21:14:33.531456Z"
     },
     "loop-progress-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "02ee5fe9c03a86d73ace09d973dd93083a933a296459cd5e142eedeeb4cb65a3",
+      "computedHash": "57de2bd6bc08d7337ff48c3bd365fba9e4ab1b6c7bf7a6fb295786c8ddee293c",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "maintain-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "",
+      "computedHash": "55999d958ed260cbf9b4d1e157f08b8ea46af03685e39f26a3b3127a736ccc24",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-27T16:54:47.092289Z"
+      "updatedAt": "2026-03-27T21:14:33.822069Z"
     },
     "manage-marketplace": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "480f65c2c001c4a57f074d5f37f07228268abf43dae11c8f0d55c011648833bb",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-27T16:49:54.144341Z"
+      "updatedAt": "2026-03-27T21:14:32.861811Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "af053cdc5bec93b3f39fc1dadd081b53f54ec0da0a4117425007d6e8ca50906f",
       "installedAt": "2026-03-23T19:00:43.520142Z",
-      "updatedAt": "2026-03-27T16:49:54.822621Z"
+      "updatedAt": "2026-03-27T21:14:33.581410Z"
     },
     "memory-management": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "9a46d7129a480f6d84de60cb65183411318e35a72a422693adafed73a768ab02",
+      "computedHash": "d9ff4421c567c71b811f9c02a33db4cc905b35ed5384ce3094b3abdf2c0811fc",
       "installedAt": "2026-03-23T19:00:43.893614Z",
-      "updatedAt": "2026-03-27T16:49:54.868674Z"
+      "updatedAt": "2026-03-27T21:14:33.628308Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "af6d066486e5121d099f060e6ff94b3a969195100ba3cd2e9d96a00bd4ad87b7",
+      "computedHash": "8080628db1a83743112a98129c444f3abf8036fbbc02a5a09752bc6e449966f0",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3a9ddef2699719c20424fa7b13254c320b422c98c5cd478f9855c0dfd5d11abd",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "6bf7145ce64619faf5099c1df1e15a230638eeccbea6ecda467c1ad58760dc83",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "2b0b478bcca2a8c471bbc78013eafd606253d066986171851d6aace087b3e61c",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "96b0f962659c9b1baa622f94d0d50cc2d0f6b1f55a175887264b7bd328f92554",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a898282dc1a03b9ffc229eca22baf219beae31b8504c764c6f9e1611a30cc158",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "94d1efad6d254cb0d6519f267774387733f1eac443562ed139312967a0d0006e",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "26816ca2c136cb89ce50141e3ad59e9fd3ddaf886881e9520d8d521109278553",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-27T16:49:55.017310Z"
+      "updatedAt": "2026-03-27T21:14:33.752685Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "030aeebc92b9b30f48a554027d7c9ff019e2f281e971a6d140b1c48595a0a461",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "87aa805ad2fab2205638185dee1327c476075fcc17ecc9757faff1fea281a184",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "06c139841659b42450eddf97bb1f2e791022128520f5f9a40cfc8dce199736bd",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "package-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "",
+      "computedHash": "b345cbfe4a95fef506608d2f923273628df74ce5aca3e50468cc8662618be095",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-27T16:54:47.092289Z"
+      "updatedAt": "2026-03-27T21:14:33.822069Z"
     },
     "path-reference-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "14db3c6063c0a82ae41d16e9cca53f44e2f3bbe36f5eabb169165085501c8c2d",
+      "computedHash": "ff5d6b8db80ee4508dc7fb894a1b6c1ab252697ff1e5c9dc21c573dafb67df75",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -645,119 +645,119 @@
       "sourceType": "local",
       "computedHash": "1b1a6943467a83609e28bd69ce23b13708b6c71d32a3b1be139c5954da4777e0",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "red-team-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "c676b40146e8fbea0d603de2a74cdbb65bbf6f80024723cbb38be57da97a050b",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-27T16:49:53.740391Z"
+      "updatedAt": "2026-03-27T21:14:32.393995Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "",
+      "computedHash": "9e2470e8d4fe2525ff6d40579828e011a99ab61057f1731ea6df2667eaa9984c",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-27T16:54:47.092289Z"
+      "updatedAt": "2026-03-27T21:14:33.822069Z"
     },
     "requesting-code-review": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "ef8c91e6b51d867b680fd361807862232f6d7aed6f923d902a5ab9eb1e39dcbe",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "7a0b82decc7878a56690cbcd90e4d8ed999b9d5e593ffb4b434d6062c78d9f33",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "9b211de5bd68d4ac3957129db68690281b421a740f8a12f774efddefc50a658a",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "9c11dd6d30d18d9e7f8a0c5f47c01dc7ad0815ff8d470eb87bf0cf1a96f06f59",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a67c1f2f2f112ae7311fdb2c67e224852698ea51084bde1aecc5a1d0c060fa35",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-factory-rlm-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "1b14164f125e5f02bb61b56c092d9cf9a8cb5aab9c1866abb0231d77fadcaf1d",
+      "computedHash": "200ca9e85e69f71a141fb33f5c0d3b5e1157f085d3f6bfbce8b424ff2135be2a",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-factory-rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "9550f25382d1fa8e2e6fcd0f55a08bcefec2f2d269eb4d8a8a5795f071f0ae0d",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-factory-rlm-distill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "f42edefc7145a3ea0cf990d3403549cfb46a33f6916f9409099c257f3de65dd7",
+      "computedHash": "60b6ee593d5df4a809bf36ef033d802bdac55b9d5af1ec25abd2cf47cf63b2f8",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-factory-rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a144228bffd2de03c4aff319f2e24771bcc1d7f44fce54ed86adedf285bcced6",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "4f2994465b7b46e44a345f49429ae7f5ac2e3a6b2d46926bc19baa64fecdea8f",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "2debd6e499df3ba8348ff9e5488c757d4092a9b6306dd9d5e32ff75e721ce317",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-27T16:49:55.613483Z"
+      "updatedAt": "2026-03-27T21:14:34.331020Z"
     },
     "rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "3e73be5ae159f646b13d785a91c3a97490bc20cc4269f289f77d962f3343a301",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-03-27T16:49:55.674229Z"
+      "updatedAt": "2026-03-27T21:14:34.384428Z"
     },
     "rsvp-reading": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "fe51eb4604ef53ee4fa67d02ddb7ba1ddab26452881157af3218cb5c1d9cfb1f",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-03-27T16:49:55.674229Z"
+      "updatedAt": "2026-03-27T21:14:34.384428Z"
     },
     "rsvp-speed-reader-rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "47f8364dc671c236ae1f94a7372539a13dbb4a99bff4ce50bad653ce49c7b55e",
       "installedAt": "2026-03-19T23:20:43.822021Z",
-      "updatedAt": "2026-03-27T16:49:55.674229Z"
+      "updatedAt": "2026-03-27T21:14:34.384428Z"
     },
     "sanctuary-memory": {
       "source": "richfrem/Project_Sanctuary",
@@ -789,28 +789,28 @@
       "sourceType": "local",
       "computedHash": "9ad38f2a051f1c3925472bb890edb194bac4332e2843c97441e70fb1de8bcb1d",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "d510fa1fdc6508387ff6e03233b4b28b4e9a063df9653cda955d7d124295a9a9",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "skill-improvement-eval": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "8fca36032e08cbacfa1a66723cb6660103b00ee5de450a221bcb722682b8fe1e",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "spec-kitty-accept": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "80d78105d68219020b5088ad83866157838cc104679fdfa530a94275ad7494a2",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-agent": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -822,161 +822,161 @@
       "sourceType": "local",
       "computedHash": "1feeb97ed203569664be36a3c8296ec43e95dccaebd3afb9c786186b772a7325",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-checklist": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3275152f05a60eb90d36117195488b3a8bece919e3187911b7dc2ce695da5b5c",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-clarify": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a0d8e6ee23e1ce7cb093a0e452a173cb412d0915e8befce3dcc0c094b9287530",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-constitution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "b85f850bb628be9137a676c945044ce32cc3efc88922e60d3f62b883043e492d",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-dashboard": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "4735d461f9f42da47dd6eccc58125344feafab4a41d509377dd47dc4198e8042",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-implement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "12377b47464af4b9cb07eea98fcdc34c3b73634b7978272a2011aaeedd7459bc",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-merge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "b36508fc30685c2644f22a89f0a1b673e1b8a08d5060b2d10c8afa2f77f41bbf",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-plan": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3bb60e4e6e2c8ee6eaaf0525f49a981d845da3153cbc4fa08b3561adc0997449",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-research": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "5640c8c55ec49f1031ec9ca3f85d3c07c62573af2ba450407809c9544c202488",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "58386b967489f7f74caf998d4f50474b8127e2cdcc049b8c3c18b607f54f6907",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-spec-kitty-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "3c570450fc117c782c3681696109b3eabbb2e720e498872e9af4a841689ce8fe",
       "installedAt": "2026-03-19T23:20:44.505553Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-spec-kitty-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "62434792618916b66dea1f2fe6988c90ffe8815e66f59ed91d77650f3039e376",
       "installedAt": "2026-03-23T05:09:41.336827Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-specify": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "146ff5dabc4a76f4bbf5b136824e7f0633894be34acdb1fb78d4728c709b1007",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-status": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "173ea851ca5b116e391e624565a59859a9d1c559dfe6300ae87e58d830651653",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-sync-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "7cd2b4fec601b8af92518498632e97b4b9c72c050bdb989c91e62b71afae2e2b",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-tasks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "c3271941de09422694d5da90a53e8af2679631331a782046a2e092fe211f251c",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-tasks-finalize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a5dc907a14898320351c258b97c7229c52b85cfd0381c8df458e7c32f429e296",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-tasks-outline": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "cedb77d913e7224f4af9590f420c131a34b07fd3c4a3d5e3bc120880bec67bd9",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-tasks-packages": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "8716c4d8115f56b1e680378d6939a9d20dbb7b60141752b3864270fa65fbf5a4",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "spec-kitty-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "2ce326b6ee05afe45cafbf570c19db726a5165733ae3586029a5d98e0b9ffdba",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-27T16:49:55.773390Z"
+      "updatedAt": "2026-03-27T21:14:34.478678Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "aeff26516e243a6faa8c32e9ef7afe10f022a6c8869418c4fbeeece64264b59c",
+      "computedHash": "c79a44d8ec2731574665d0998c156e0f94ffc70262ad2f47811d41459d343c87",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-27T16:49:53.833452Z"
+      "updatedAt": "2026-03-27T21:14:32.500999Z"
     },
     "systematic-debugging": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "6ccd694bc10f5323d3ed56447494b475263b7493b7e46624c8148cd6be258004",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "8caac6a7e695b094a977764a8895770ba6abc5f92618c3d1b470283eff62de26",
+      "computedHash": "0345b17156670c4a0ef47984c6964db3333eba2c754b75a478f205206631192d",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-03-27T16:49:55.867405Z"
+      "updatedAt": "2026-03-27T21:14:34.527281Z"
     },
     "task-manager-task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -990,105 +990,105 @@
       "sourceType": "local",
       "computedHash": "0622ae100aa445a2b724be7cffcaf0439d22d0ab2e2e69a67af3e7c8d728a9d8",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "todo-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "060182931cad9b73b7f09ffd0204026c4b96243a9aaefe372dc5fa09d1e4e1ef",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-27T16:49:53.577103Z"
+      "updatedAt": "2026-03-27T21:14:32.277263Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "abd3d15d4a28c207faabec60fc7f7ba2b93fa7f3bc47983fbcb7ba7cabcf286c",
+      "computedHash": "0981d465f608df9e7130fffc281c7680cf16baff85b9e3b8fb752a23c6c69324",
       "installedAt": "2026-03-23T19:00:53.050183Z",
-      "updatedAt": "2026-03-27T16:49:55.931386Z"
+      "updatedAt": "2026-03-27T21:14:34.590485Z"
     },
     "tool-inventory-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a37f45bf4edd793fdac2513a4d57b42fb3b1cdd6558bc5ce5c0909434224134d",
       "installedAt": "2026-03-23T19:00:53.050183Z",
-      "updatedAt": "2026-03-27T16:49:55.931386Z"
+      "updatedAt": "2026-03-27T21:14:34.590485Z"
     },
     "user-story-capture": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "9f971658d024265c96c391c8a0f5c35374e35ea910172977a5e048e77c65156b",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-27T16:49:54.627983Z"
+      "updatedAt": "2026-03-27T21:14:33.381954Z"
     },
     "using-git-worktrees": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "74026d48693e4e85520825a2c21b1b4ec5c35e4901713e061567ee4188fcd9cc",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "f3190ca92470b9a2fae0a68adcaba2756fffb5a900507e9bb38da8b4eadf780c",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "ced4a62cf41e4b2a5196e30ada6d669ce7f4038976e2459f909b56bfd8c36e80",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "2e6e6275e5a515d8a5039740e36185373ff5b1500ec403e243862b883bcc340c",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "ec142c127bd2b9efc641bfc092b5dc16f5f4566a090b948006e04f8c7064e6b8",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
-      "computedHash": "19603f88b590d91e1d3723107ce3062c4c69cc0725ec01bac77dd94386df624a",
+      "computedHash": "1f54eb329916887d80609f82001ca1dbb6484d3f1e72a846a6004cc75ac46ab1",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "a9ffe9e2116ddc3007572769521336c7e1fca600d827a12bd3a8132a4216d202",
       "installedAt": "2026-03-19T23:20:45.283733Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "vector-db-vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "aa484fc90e37086119b30d302fe88669f3a8516ccaec0ad909b3cde1d0b08063",
       "installedAt": "2026-03-19T23:20:45.283733Z",
-      "updatedAt": "2026-03-27T16:49:56.014443Z"
+      "updatedAt": "2026-03-27T21:14:34.667959Z"
     },
     "verification-before-completion": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "f04c3e05939d822b2b7a29d6d9c2382b93e79789fef61bbc44284baa3aa413d7",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-27T16:49:53.627582Z"
+      "updatedAt": "2026-03-27T21:14:32.327220Z"
     },
     "zip-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "d0c6005cb0cd1e4f14c0f2985504989e1687b2bc03374c1dcc4cd07a45b85302",
       "installedAt": "2026-03-23T19:00:38.312643Z",
-      "updatedAt": "2026-03-27T16:49:54.395113Z"
+      "updatedAt": "2026-03-27T21:14:33.145930Z"
     }
   }
 }


### PR DESCRIPTION
… equivalents

Replace hardcoded plugins/ source-repo paths with portable, consumer-repo-safe paths across 23 files (64 changes total). Affects SKILL.md files, agent dispatch commands, and cross-skill references.

Changes by category:
- T1 (cross-skill refs): plugins/<P>/skills/<S>/ -> .agents/skills/<S>/
- T2 (--agent flags): plugins/<P>/agents/<N>.md -> .agents/skills/<P>-<N>/SKILL.md
- T3 (copilot cat dispatch): plugins/<P>/agents/<N>.md -> .agents/skills/ path
- T4 (PLUGIN_DIR fallback): plugins/agent-agentic-os -> .agents/skills/agent-agentic-os
- T5 (memory mgmt table): plugins/<name>/ -> .agents/skills/ with skill list
- T6 (dead ref removal): plugins/personas/ -> description pointing to agents/ dir
- T7 (tool inventory): plugins/tool_inventory.json -> project-root tool_inventory.json
- T8 (coding conventions): plugins/templates/ -> ./scripts/ (within-skill relative)

False positives explicitly left unchanged:
- Architecture diagrams describing source-repo layout
- Tool argument examples where plugins/ is user-supplied input
- npx skills add ./plugins/ installation instructions in READMEs
- spec-kitty-sync-plugin (runs in source repo by design)
- context-bundler JSON examples (user bundles any path they choose)

Fixes: consumer-repo portability (ADR-003 compliance)