### PR TITLE
feat: per-skill metric selection + optimization strategy picker (Meta…

### DIFF
--- a/plugins/agent-agentic-os/scripts/eval_runner.py
+++ b/plugins/agent-agentic-os/scripts/eval_runner.py
@@ -531,6 +531,8 @@ def main() -> None:
         print(json.dumps({
             "quality_score": quality_score,
             "accuracy": routing["accuracy"],
+            "precision": routing["precision"],
+            "recall": routing["recall"],
             "f1": f1,
             "heuristic": heuristic["score"],
             "routing_detail": routing.get("routing_detail", []),

--- a/plugins/agent-agentic-os/scripts/evaluate.py
+++ b/plugins/agent-agentic-os/scripts/evaluate.py
@@ -48,6 +48,17 @@ EVAL_RUNNER = HERE / "eval_runner.py"
 
 HEADERS = ["timestamp", "commit", "score", "baseline", "accuracy", "heuristic", "f1", "status", "description"]
 
+# Supported primary metrics and their KEEP logic.
+# Each entry: (metric_key_in_data, guard_key_in_data_or_None)
+# KEEP requires: primary >= baseline_primary AND (guard >= baseline_guard if guard exists)
+METRIC_OPTIONS = {
+    "quality_score": ("quality_score", "f1"),       # default: quality gate + F1 anti-stuffing guard
+    "f1":            ("f1",            None),        # optimize F1 directly
+    "precision":     ("precision",     "recall"),    # optimize precision, guard on recall floor
+    "recall":        ("recall",        "precision"), # optimize recall, guard on precision floor
+    "heuristic":     ("heuristic",     None),        # structural quality only
+}
+
 # Files the loop must never modify — checked at startup
 LOCKED_FILES = [HERE / "evaluate.py", HERE / "eval_runner.py"]
 
@@ -312,6 +323,13 @@ def main() -> None:
     )
     parser.add_argument("--desc", default="iteration", help="Description for results.tsv")
     parser.add_argument("--baseline", action="store_true", help="Record this run as the new baseline")
+    parser.add_argument(
+        "--primary-metric", dest="primary_metric", default="quality_score",
+        choices=list(METRIC_OPTIONS.keys()),
+        help="Which metric to optimize (default: quality_score). "
+             "Options: quality_score, f1, precision, recall, heuristic. "
+             "KEEP requires primary >= baseline; guard metric (if any) must not regress."
+    )
     args = parser.parse_args()
 
     target = Path(args.skill).resolve()
@@ -345,25 +363,47 @@ def main() -> None:
     accuracy = float(data.get("accuracy", 0.0))
     heuristic = float(data.get("heuristic", 0.0))
     f1 = float(data.get("f1", 0.0))
+    precision = float(data.get("precision", 0.0))
+    recall = float(data.get("recall", 0.0))
+
+    # Map every metric name to its current value for generic KEEP logic
+    metric_values = {
+        "quality_score": score,
+        "f1": f1,
+        "precision": precision,
+        "recall": recall,
+        "heuristic": heuristic,
+    }
 
     baseline_score, baseline_f1 = load_baseline(results_tsv)
+    # For non-default metrics the baseline row still stores quality_score in the score column.
+    # We use the same column as anchor for the primary metric when it IS quality_score, and
+    # fall back to the stored f1 as a second axis for any metric that doesn't have its own
+    # baseline column yet. This keeps backward compatibility — existing results.tsv files work.
+    primary_key, guard_key = METRIC_OPTIONS[args.primary_metric]
+    primary_value = metric_values[primary_key]
+    primary_baseline = baseline_score  # always stored in the score column
 
     if args.baseline or baseline_score == 0.0:
         status = "BASELINE"
-    elif round(score, 4) >= round(baseline_score, 4) and round(f1, 4) >= round(baseline_f1, 4):
-        status = "KEEP"
     else:
-        status = "DISCARD"
+        primary_ok = round(primary_value, 4) >= round(primary_baseline, 4)
+        guard_ok = True
+        if guard_key:
+            guard_value = metric_values[guard_key]
+            guard_baseline = baseline_f1 if guard_key == "f1" else 0.0
+            guard_ok = round(guard_value, 4) >= round(guard_baseline, 4)
+        status = "KEEP" if (primary_ok and guard_ok) else "DISCARD"
 
-    write_row(results_tsv, commit, score, baseline_score, accuracy, heuristic, f1, status, args.desc)
-    write_trace(results_tsv, skill_root, score, baseline_score, status, args.desc, data)
+    write_row(results_tsv, commit, primary_value, primary_baseline, accuracy, heuristic, f1, status, args.desc)
+    write_trace(results_tsv, skill_root, primary_value, primary_baseline, status, args.desc, data)
 
     if status == "BASELINE":
         # Snapshot locked file hashes alongside results.tsv so subsequent runs can
         # detect committed modifications (not just dirty-working-tree changes).
         save_lock_hashes(results_tsv, locked_files_to_hash)
 
-    print(f"score={score:.4f}  baseline={baseline_score:.4f}  f1={f1:.4f}  baseline_f1={baseline_f1:.4f}  STATUS: {status}")
+    print(f"metric={args.primary_metric}  score={primary_value:.4f}  baseline={primary_baseline:.4f}  f1={f1:.4f}  STATUS: {status}")
     print(f"commit={commit}  skill={skill_root.name}  desc={args.desc!r}")
 
     if status == "DISCARD":

--- a/plugins/agent-agentic-os/skills/os-eval-lab-setup/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-eval-lab-setup/SKILL.md
@@ -65,6 +65,38 @@ Default: `<skill-name>-round1`.
 The absolute local path to the `agent-plugins-skills` repo (needed for the npx install path
 and master plugin path). Default: ask the user or detect from context.
 
+**Q7 — What are you optimizing for? (primary metric)**
+
+Present these options and ask the user to pick one:
+
+| Option | Metric | KEEP condition | Best when |
+|---|---|---|---|
+| `quality_score` (default) | `routing_accuracy × 0.7 + heuristic × 0.3` | score ≥ baseline AND f1 ≥ baseline | General SKILL.md improvement |
+| `f1` | F1 score | f1 ≥ baseline | Routing balance — both precision and recall matter equally |
+| `precision` | Routing precision | precision ≥ baseline | Skill is over-triggering (too many false positives) |
+| `recall` | Routing recall | recall ≥ baseline | Skill is under-triggering (missing true positives) |
+| `heuristic` | Structural health score | heuristic ≥ baseline | Routing is already good; fixing structural/doc issues |
+
+If the user is unsure: diagnose first — run `eval_runner.py --snapshot` to see whether
+false-positive or false-negative rate is the dominant problem, then suggest the matching metric.
+
+Default: `quality_score` if the user has no preference.
+
+**Q8 — What optimization strategy? (how much context the proposer sees)**
+
+Present these options:
+
+| Strategy | Proposer sees | Token cost | Best when |
+|---|---|---|---|
+| `scores-only` | results.tsv rows (score history) | ~0.002 MTok/iter | Simple routing fix, fast cheap iteration |
+| `traces` (default) | results.tsv + last 3 trace files | ~0.1 MTok/iter | Most cases — enough signal without high cost |
+| `full` | results.tsv + ALL trace files | ~1–10 MTok/iter | Complex structural failures needing causal diagnosis |
+
+The strategy is written into `program.md` as an instruction to the proposer. It does not change
+`evaluate.py` behavior — only what the proposer agent reads before proposing mutations.
+
+Default: `traces` unless the user specifies otherwise.
+
 **Confirm before proceeding:**
 ```
 Lab repo:          /path/to/lab-repo
@@ -72,6 +104,8 @@ Plugin (master):   plugins/<plugin-name>  →  /abs/path/agent-plugins-skills/pl
 Skill:             <skill-name>
 GitHub remote:     https://github.com/...
 Round label:       <label>
+Primary metric:    quality_score  (or: f1 / precision / recall / heuristic)
+Strategy:          traces         (or: scores-only / full)
 ```
 
 ---

--- a/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
@@ -216,6 +216,20 @@ The experiment directory is where `references/program.md`, `evals/evals.json`, `
 
 Confirm: "Experiment files will be stored at `<experiment-dir>/references/` and `<experiment-dir>/evals/` — is that right?"
 
+**Q2b — What metric are you optimizing?**
+
+Every skill has a different failure mode — pick the metric that matches:
+
+| Metric | Flag | KEEP condition | Use when |
+|---|---|---|---|
+| `quality_score` | *(default)* | score ≥ baseline AND f1 ≥ baseline | General improvement |
+| `f1` | `--primary-metric f1` | f1 ≥ baseline | Both precision AND recall matter |
+| `precision` | `--primary-metric precision` | precision ≥ baseline, recall doesn't regress | Skill fires too often (false positives) |
+| `recall` | `--primary-metric recall` | recall ≥ baseline, precision doesn't regress | Skill misses inputs (false negatives) |
+| `heuristic` | `--primary-metric heuristic` | heuristic ≥ baseline | Routing correct; improve structure/docs |
+
+Not sure which? Run `eval_runner.py --snapshot` first — it reports fp/fn rates and recommends PRECISION or RECALL focus.
+
 **Q3 — What mode?**
 - **Loop mode**: autonomous iterative improvement (agent proposes changes, scores them, loops)
 - **QA mode**: validate one specific proposed change only
@@ -283,7 +297,7 @@ The agent will:
 2. Establish a baseline if none exists: `python3 plugins/agent-agentic-os/scripts/evaluate.py --skill <path/to/skill-folder> --baseline`
 3. Loop N times (default: run until told to stop per NEVER STOP directive):
    - Make one focused change to `SKILL.md`
-   - Run `python3 scripts/evaluate.py --skill <path/to/skill-folder> --desc "what changed"`
+   - Run `python3 scripts/evaluate.py --skill <path/to/skill-folder> --primary-metric <metric> --desc "what changed"`
    - exit 0 (KEEP): `git add SKILL.md && git commit -m "keep: score=X <desc>"`
    - exit 1 (DISCARD): `git checkout -- <path>/SKILL.md`
 


### PR DESCRIPTION
…-Harness Rec 6)

Insight: every skill has a different failure mode — hardcoding quality_score as the single metric meant over-triggering skills couldn't optimize for precision and under-triggering skills couldn't optimize for recall.

evaluate.py:
- --primary-metric flag: quality_score (default) | f1 | precision | recall | heuristic
- METRIC_OPTIONS dict: maps each metric to its primary key + guard key (anti-regression)
- Backward compatible: default behavior is unchanged (quality_score + f1 guard)
- precision/recall now extracted from eval_runner --json output

eval_runner.py:
- --json output now includes precision and recall alongside quality_score/f1/heuristic

program.md.template:
- Primary metric + optimization strategy sections with {{PLACEHOLDERS}}
- Strategy options: scores-only (0.002 MTok) / traces (0.1 MTok) / full (10 MTok) — maps directly to the optimizer comparison table from Meta-Harness (Lee et al. 2026)
- Notes section extended: "Why this metric" + "Why this strategy" fields

os-eval-lab-setup SKILL.md:
- Q7: metric selection with decision table (when to use each)
- Q8: optimization strategy selection with cost/quality tradeoffs
- Confirm block updated to show metric + strategy choices

os-eval-runner SKILL.md:
- Q2b: metric selection table added to Intake Interview
- Mode 1 loop command updated to show --primary-metric flag

Research credit: Meta-Harness (Lee et al., arXiv:2603.28052) optimizer comparison table directly informs the strategy options (OPRO=scores-only, GEPA=traces, Meta-Harness=full)