### PR TITLE
fix: reconfigure stdout/stderr to UTF-8 on Windows to prevent Unicode…

### DIFF
--- a/plugins/link-checker/scripts/symlink_manager.py
+++ b/plugins/link-checker/scripts/symlink_manager.py
@@ -28,6 +28,12 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Literal
 
+# Ensure Unicode output works on Windows terminals that default to cp1252
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…EncodeError

The symlink_manager.py script uses Unicode check/cross marks (✓/✗) that fail to encode with Windows' default cp1252 console encoding. This adds a UTF-8 reconfigure at startup so the script runs correctly without needing PYTHONIOENCODING=utf-8 set manually.