### PR TITLE
fix(bridge-installer): remove duplicate agent skill-wrapper installat…

### DIFF
--- a/plugins/plugin-manager/scripts/bridge_installer.py
+++ b/plugins/plugin-manager/scripts/bridge_installer.py
@@ -111,16 +111,44 @@ def _is_pointer_file(path: Path) -> bool:
         return False
 
 
+# Directories that should never be copied into .agents/skills/ — runtime
+# artifacts and dependency caches that are large, irrelevant to agents, and
+# would cause multi-minute installs (e.g. xml-to-markdown's node_modules).
+COPY_EXCLUDE_DIRS = frozenset({
+    "node_modules",
+    "venv",
+    ".venv",
+    "env",
+    ".env",
+    "__pycache__",
+    ".git",
+    ".hg",
+    ".svn",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    "coverage",
+    ".nyc_output",
+})
+
+
 def _copy_resolving_pointers(src_dir: Path, dst_dir: Path) -> None:
     """Recursively copy src_dir to dst_dir.
     Pointer files (single-line '../...' paths) are resolved to their real target
     so the installed copy in .agents/ is fully self-contained and works in any
     consuming project that has no plugins/ source tree.
+
+    Directories listed in COPY_EXCLUDE_DIRS (node_modules, venv, __pycache__,
+    .git, dist, etc.) are silently skipped — they are runtime artifacts that
+    are large, irrelevant to agent operation, and would cause very slow installs.
     """
     dst_dir.mkdir(parents=True, exist_ok=True)
     for item in src_dir.iterdir():
         dst_item = dst_dir / item.name
         if item.is_dir():
+            if item.name in COPY_EXCLUDE_DIRS:
+                continue  # skip heavy runtime artifact dirs (node_modules, venv, etc.)
             _copy_resolving_pointers(item, dst_item)
         elif item.is_file():
             try:
@@ -417,47 +445,12 @@ def provision_central_and_symlink(plugin_path: Path, metadata: dict, targets: li
                     _symlink_or_copy(dest, target_symlink, dry_run, root, config["name"])
                     
     # 4. Standalone Agents:
-    #    - For IDEs with native agents/ dirs (e.g. Claude): deploy .md files directly there.
-    #    - For IDEs without native agents/ dirs (e.g. Antigravity): wrap in a SKILL.md wrapper.
-    agents_dir_src = plugin_path / "agents"
-    if agents_dir_src.exists():
-        # Targets WITHOUT a native agents dir get the skill-wrapper treatment
-        non_native_agent_targets = [
-            t for t in targets
-            if not DETECTABLE_AGENTS.get(t, {}).get("agents")
-        ]
-
-        for agent_file in agents_dir_src.glob("*.md"):
-            agent_name = agent_file.stem
-            final_name = plugin_name if plugin_name.endswith(agent_name) else f"{plugin_name}-{agent_name}"
-
-            dest = central_skills / final_name
-            if not dry_run:
-                dest.mkdir(parents=True, exist_ok=True)
-                for opt_dir in ["scripts", "references", "assets", "evals"]:
-                    (dest / opt_dir).mkdir(exist_ok=True)
-                shutil.copy2(agent_file, dest / "SKILL.md")
-                print(f"  ✓ Universal central copy (Agent Wrapper): {dest.relative_to(root)}")
-            else:
-                print(f"  [DRY RUN] Universal central copy (Agent Wrapper): .agents/skills/{final_name}")
-
-            installed_skills.append(final_name)
-
-            for target_dir_name in non_native_agent_targets:
-                config = DETECTABLE_AGENTS.get(target_dir_name)
-                if not config or not config.get("skills"):
-                    continue
-
-                ide_dir = root / target_dir_name
-                if not ide_dir.exists():
-                    continue
-
-                ide_skills = root / config["skills"]
-                if not dry_run:
-                    ide_skills.mkdir(parents=True, exist_ok=True)
-
-                target_symlink = ide_skills / final_name
-                _symlink_or_copy(dest, target_symlink, dry_run, root, config["name"])
+    #    Agents are flat .md files with YAML frontmatter (name, description, tools, model, etc.)
+    #    per the Anthropic subagents spec. They are NOT SKILL.md wrappers.
+    #    All platforms (Claude, Antigravity, Gemini, Copilot) read agents from
+    #    .agents/agents/ as the canonical store. Claude Code additionally gets a
+    #    symlink at .claude/agents/ via deploy_agents() below.
+    #    No skill-wrapper duplication is performed here.
 
     # 5. Native Hooks (e.g. for PreToolUse, Subagent events)
     hooks_file = plugin_path / "hooks" / "hooks.json"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,63 +11,63 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-03-31T19:32:24.091582Z"
+      "updatedAt": "2026-03-31T19:52:03.142013Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "agent-agentic-os-os-health-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "agent-agentic-os-os-learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:37.453182Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "agent-agentic-os-os-nightly-evolver": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:53:47.989943Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "agent-execution-disciplines-code-reviewer": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "agent-loops-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:37.731809Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "agent-plugin-analyzer-l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:38.237081Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "agent-swarm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -88,84 +88,84 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "antigravity-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:45.204613Z",
-      "updatedAt": "2026-03-31T19:32:36.329197Z"
+      "updatedAt": "2026-03-31T19:52:23.620922Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "auto-update-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:14.650371Z",
-      "updatedAt": "2026-03-31T19:32:39.043837Z"
+      "updatedAt": "2026-03-31T19:52:27.927217Z"
     },
     "business-requirements-capture": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "business-workflow-doc": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:37.067705Z",
-      "updatedAt": "2026-03-31T19:32:33.695149Z"
+      "updatedAt": "2026-03-31T19:52:19.267189Z"
     },
     "claude-cli-claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:40.774857Z",
-      "updatedAt": "2026-03-31T19:32:33.695149Z"
+      "updatedAt": "2026-03-31T19:52:19.267189Z"
     },
     "claude-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:44.824639Z",
-      "updatedAt": "2026-03-31T19:32:33.695149Z"
+      "updatedAt": "2026-03-31T19:52:19.267189Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:37.700984Z",
-      "updatedAt": "2026-03-31T19:32:34.002325Z"
+      "updatedAt": "2026-03-31T19:52:19.841948Z"
     },
     "coding-conventions-coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:40.949622Z",
-      "updatedAt": "2026-03-31T19:32:34.002325Z"
+      "updatedAt": "2026-03-31T19:52:19.841948Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -184,7 +184,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-03-31T19:32:34.276095Z"
+      "updatedAt": "2026-03-31T19:52:20.327002Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -205,63 +205,63 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-03-31T19:32:37.746667Z"
+      "updatedAt": "2026-03-31T19:52:26.051184Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:38.954419Z",
-      "updatedAt": "2026-03-31T19:32:34.622638Z"
+      "updatedAt": "2026-03-31T19:52:20.887510Z"
     },
     "copilot-cli-copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:41.317243Z",
-      "updatedAt": "2026-03-31T19:32:34.622638Z"
+      "updatedAt": "2026-03-31T19:52:20.887510Z"
     },
     "create-agentic-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -273,77 +273,77 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "deferred": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "dependency-management": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-03-31T19:32:34.879591Z"
+      "updatedAt": "2026-03-31T19:52:21.249697Z"
     },
     "dual-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-03-31T19:32:33.451568Z"
+      "updatedAt": "2026-03-31T19:52:18.874444Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-03-31T19:32:33.451568Z"
+      "updatedAt": "2026-03-31T19:52:18.874444Z"
     },
     "eval-autoresearch-fit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:54:04.213659Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -355,119 +355,119 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.705846Z",
-      "updatedAt": "2026-03-31T19:32:35.108012Z"
+      "updatedAt": "2026-03-31T19:52:21.583399Z"
     },
     "exploration-cycle-plugin-business-rule-audit-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-exploration-cycle-orchestrator-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-exploration-loop-orchestrator": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-handoff-preparer-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-intake-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-planning-doc-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-problem-framing-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-prototype-companion-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-requirements-doc-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-cycle-plugin-requirements-scribe-agent": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:40.270524Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-handoff": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-optimizer": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-session-brief": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "exploration-workflow": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "finishing-a-development-branch": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -479,63 +479,63 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.069557Z",
-      "updatedAt": "2026-03-31T19:32:36.329197Z"
+      "updatedAt": "2026-03-31T19:52:23.620922Z"
     },
     "gemini-cli-gemini-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:41.911092Z",
-      "updatedAt": "2026-03-31T19:32:36.329197Z"
+      "updatedAt": "2026-03-31T19:52:23.620922Z"
     },
     "hf-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-03-31T19:32:36.604525Z"
+      "updatedAt": "2026-03-31T19:52:24.102947Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-03-31T19:32:36.604525Z"
+      "updatedAt": "2026-03-31T19:52:24.102947Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-03-31T19:32:43.444274Z"
+      "updatedAt": "2026-03-31T19:52:35.142754Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:43.095665Z",
-      "updatedAt": "2026-03-31T19:32:37.070946Z"
+      "updatedAt": "2026-03-31T19:52:24.910538Z"
     },
     "link-checker-link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:42.398817Z",
-      "updatedAt": "2026-03-31T19:32:37.070946Z"
+      "updatedAt": "2026-03-31T19:52:24.910538Z"
     },
     "loop-progress-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -549,112 +549,112 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-31T19:32:39.043837Z"
+      "updatedAt": "2026-03-31T19:52:27.927217Z"
     },
     "manage-marketplace": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-03-31T19:32:32.399195Z"
+      "updatedAt": "2026-03-31T19:52:15.671703Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:43.520142Z",
-      "updatedAt": "2026-03-31T19:32:37.250476Z"
+      "updatedAt": "2026-03-31T19:52:25.189430Z"
     },
     "memory-management": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:43.893614Z",
-      "updatedAt": "2026-03-31T19:32:37.526045Z"
+      "updatedAt": "2026-03-31T19:52:25.575120Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-03-31T19:32:38.393435Z"
+      "updatedAt": "2026-03-31T19:52:27.285266Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-eval-lab": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -668,56 +668,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:55:32.819746Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "package-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -731,14 +731,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "plugin-installer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-03-31T19:32:39.043837Z"
+      "updatedAt": "2026-03-31T19:52:27.927217Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -750,21 +750,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "red-team-bundler": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-03-31T19:32:34.276095Z"
+      "updatedAt": "2026-03-31T19:52:20.327002Z"
     },
     "red-team-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-03-31T19:32:26.694455Z"
+      "updatedAt": "2026-03-31T19:52:06.829993Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -778,98 +778,98 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-factory-rlm-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-factory-rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-factory-rlm-distill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-factory-rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:43.638971Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-03-31T19:32:40.041819Z"
+      "updatedAt": "2026-03-31T19:52:29.835089Z"
     },
     "rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-03-31T19:32:40.382888Z"
+      "updatedAt": "2026-03-31T19:52:30.349665Z"
     },
     "rsvp-reading": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-03-31T19:32:40.382888Z"
+      "updatedAt": "2026-03-31T19:52:30.349665Z"
     },
     "rsvp-speed-reader-rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:43.822021Z",
-      "updatedAt": "2026-03-31T19:32:40.382888Z"
+      "updatedAt": "2026-03-31T19:52:30.349665Z"
     },
     "sanctuary-memory": {
       "source": "richfrem/Project_Sanctuary",
@@ -901,7 +901,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -922,7 +922,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-agent": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -934,168 +934,168 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-checklist": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-clarify": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-constitution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-dashboard": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-implement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-merge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-plan": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-research": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-spec-kitty-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:44.505553Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-spec-kitty-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T05:09:41.336827Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-specify": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-status": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-sync-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-tasks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-tasks-finalize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-tasks-outline": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-tasks-packages": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "spec-kitty-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-03-31T19:32:41.920013Z"
+      "updatedAt": "2026-03-31T19:52:32.841532Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-31T19:06:22.971138Z",
-      "updatedAt": "2026-03-31T19:32:37.070946Z"
+      "updatedAt": "2026-03-31T19:52:24.910538Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-03-31T19:32:28.337036Z"
+      "updatedAt": "2026-03-31T19:52:09.885457Z"
     },
     "systematic-debugging": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-03-31T19:32:42.148651Z"
+      "updatedAt": "2026-03-31T19:52:33.200728Z"
     },
     "task-manager-task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1109,98 +1109,98 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "todo-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-03-31T19:32:25.441955Z"
+      "updatedAt": "2026-03-31T19:52:05.183466Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:53.050183Z",
-      "updatedAt": "2026-03-31T19:32:42.504215Z"
+      "updatedAt": "2026-03-31T19:52:33.779901Z"
     },
     "tool-inventory-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:53.050183Z",
-      "updatedAt": "2026-03-31T19:32:42.504215Z"
+      "updatedAt": "2026-03-31T19:52:33.779901Z"
     },
     "user-story-capture": {
       "source": "exploration-cycle-plugin",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-03-31T19:32:36.036538Z"
+      "updatedAt": "2026-03-31T19:52:23.211834Z"
     },
     "using-git-worktrees": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:45.283733Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "vector-db-vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-19T23:20:45.283733Z",
-      "updatedAt": "2026-03-31T19:32:43.191042Z"
+      "updatedAt": "2026-03-31T19:52:34.834349Z"
     },
     "verification-before-completion": {
       "source": "agent-execution-disciplines",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-03-31T19:32:25.983539Z"
+      "updatedAt": "2026-03-31T19:52:05.881997Z"
     },
     "writing-skills": {
       "source": "https://github.com/richfrem/agent-plugins-skills",


### PR DESCRIPTION
…ion. Agents are flat .md files per Anthropic subagents spec, not SKILL.md wrappers. Removed the non-native-agent skill-wrapper block that was incorrectly double-installing agent files into .agents/skills/. deploy_agents() is now the single canonical path for all platforms.