### PR TITLE
feat: add generate_milestone.py for long autoresearch runs (Meta-Harn…

### DIFF
--- a/plugin-research/meta-harness/task-tracker.md
+++ b/plugin-research/meta-harness/task-tracker.md
@@ -1,0 +1,75 @@
+# Meta-Harness Enhancement Task Tracker
+
+**Based on:** arXiv:2603.28052 (Lee et al., March 2026)
+**Plan:** [implementation-plan.md](./implementation-plan.md)
+**Target:** `plugins/agent-agentic-os/`
+
+---
+
+## Status Summary
+
+| # | Enhancement | Priority | Status |
+|---|---|---|---|
+| 1 | Per-input trace storage (`eval_runner.py` + `evaluate.py`) | HIGH | ✅ Done (already implemented) |
+| 2 | Skill state snapshot (`--snapshot` flag) | MEDIUM | ✅ Done (already implemented) |
+| 3 | Hypothesis block in `os-skill-improvement` SKILL.md | MEDIUM | ✅ Done (already implemented) |
+| 4 | Milestone summary files (`generate_milestone.py`) | LOW | ✅ Done |
+| 5 | Two-gate backport confirmation in `os-eval-runner` Stage 6 | LOW | ✅ Done (already implemented) |
+
+---
+
+## Enhancement 1 — Per-Input Trace Storage
+
+**Status:** ✅ Done
+**Files:** `scripts/eval_runner.py`, `scripts/evaluate.py`, `skills/os-eval-runner/SKILL.md`
+
+Already fully implemented:
+- `eval_runner.py --json` outputs `routing_detail` (per-input: input, should_trigger, matched_keywords, triggered, correct, failure_reason) and `heuristic_detail`
+- `evaluate.py` has `write_trace()` — writes `evals/traces/iter_NNN_VERDICT_scoreX.XX.json` after every iteration
+- `os-eval-runner` SKILL.md documents the `traces/` directory and includes grep troubleshooting commands
+
+---
+
+## Enhancement 2 — Skill State Snapshot
+
+**Status:** ✅ Done
+**Files:** `scripts/eval_runner.py`, `skills/os-skill-improvement/SKILL.md`
+
+Already fully implemented:
+- `eval_runner.py --snapshot` calls `build_snapshot()` — reads `results.tsv` + latest trace, outputs markdown block with score trend, KEEP/DISCARD counts, fp/fn rates, dominant problem (PRECISION/RECALL), and recommended action
+- `os-skill-improvement` SKILL.md has "Required: Skill State Snapshot" step before any mutation
+
+---
+
+## Enhancement 3 — Hypothesis Block Requirement
+
+**Status:** ✅ Done
+**Files:** `skills/os-skill-improvement/SKILL.md`
+
+Already fully implemented:
+- "Required: Hypothesis Block" section in `os-skill-improvement` SKILL.md with 5-field format (Failure mode, Root cause, Change, Effect, Risk)
+- Acceptable and not-acceptable examples included
+
+---
+
+## Enhancement 4 — Milestone Summary Files
+
+**Status:** ✅ Done
+**Files:** `scripts/generate_milestone.py` (new), `skills/os-eval-runner/SKILL.md` (updated)
+
+`generate_milestone.py` created. Reads `evals/results.tsv` + `evals/traces/*.json`. Writes
+`evals/traces/milestone_NNN.md` every N iterations (default 25, `--force` to override).
+Sections: score trajectory, top KEEPs, worst DISCARDs (with repeat-attempt flagging),
+recurring false-positive inputs from last 5 traces, dominant problem, recommended focus.
+`os-eval-runner` SKILL.md updated with milestone directory entry and usage commands.
+
+---
+
+## Enhancement 5 — Two-Gate Backport Confirmation
+
+**Status:** ✅ Done
+**Files:** `skills/os-eval-runner/SKILL.md`
+
+Already fully implemented:
+- Stage 6 in `os-eval-runner` SKILL.md has two-gate protocol: Gate 1 (machine — evaluate.py exit 0) and Gate 2 (three-perspective commentary: test engineer view, routing precision view, regression view)
+- Unattended run handling: writes commentary to `temp/retrospectives/` and flags for human review before auto-applying

--- a/plugins/agent-agentic-os/scripts/generate_milestone.py
+++ b/plugins/agent-agentic-os/scripts/generate_milestone.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+generate_milestone.py -- Write milestone summary files for long autoresearch runs.
+==================================================================================
+
+Purpose:
+    Reads evals/results.tsv and evals/traces/*.json for a skill experiment directory.
+    Writes a milestone_NNN.md summary every N iterations (default: 25).
+    Enables the proposer to read distant history without losing context — the
+    Meta-Harness equivalent of proactive summarization (Lee et al., arXiv:2603.28052).
+
+    This is a pure read-then-write utility. It does not affect KEEP/DISCARD decisions
+    and must never be added to LOCKED_FILES in evaluate.py.
+
+Usage:
+    python3 generate_milestone.py --experiment-dir <path> [--every 25] [--force]
+
+    --experiment-dir   Path to the experiment directory (contains evals/ and references/)
+    --every N          Write a milestone every N iterations (default: 25)
+    --force            Write a milestone even if iteration count is not a multiple of --every
+
+Output:
+    evals/traces/milestone_NNN.md  where NNN = the iteration count at time of writing
+
+Exit codes:
+    0  Milestone written (or --force used)
+    0  No milestone needed yet (iteration count not a multiple of --every, no --force)
+    2  Error (bad path, missing results.tsv, etc.)
+"""
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _load_tsv(results_tsv: Path) -> list[dict]:
+    if not results_tsv.exists():
+        return []
+    rows = []
+    with open(results_tsv, newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def _load_traces(traces_dir: Path) -> list[dict]:
+    """Load all iter_*.json trace files, sorted by name."""
+    traces = []
+    if not traces_dir.exists():
+        return traces
+    for path in sorted(traces_dir.glob("iter_*.json")):
+        try:
+            traces.append(json.loads(path.read_text()))
+        except Exception:
+            pass
+    return traces
+
+
+def _best_keeps(iter_rows: list[dict], top_n: int = 3) -> list[str]:
+    """Return descriptions of the top-N highest-delta KEEP iterations."""
+    keep_rows = [r for r in iter_rows if r.get("status") == "KEEP"]
+    keep_rows_sorted = sorted(keep_rows, key=lambda r: float(r.get("score", 0)), reverse=True)
+    results = []
+    for row in keep_rows_sorted[:top_n]:
+        desc = row.get("description", "(no description)")
+        score = float(row.get("score", 0))
+        baseline = float(row.get("baseline", 0))
+        delta = score - baseline
+        results.append(f"  - +{delta:.4f}: \"{desc}\" (score={score:.4f})")
+    return results
+
+
+def _worst_discards(iter_rows: list[dict], top_n: int = 3) -> list[str]:
+    """Return descriptions of the top-N most negative-delta DISCARD iterations, with failure reasons."""
+    discard_rows = [r for r in iter_rows if r.get("status") == "DISCARD"]
+    discard_rows_sorted = sorted(discard_rows, key=lambda r: float(r.get("score", 0)))
+    results = []
+    seen_descs: dict[str, int] = {}
+    for row in discard_rows_sorted[:top_n]:
+        desc = row.get("description", "(no description)")
+        seen_descs[desc] = seen_descs.get(desc, 0) + 1
+    for row in discard_rows_sorted[:top_n]:
+        desc = row.get("description", "(no description)")
+        score = float(row.get("score", 0))
+        baseline = float(row.get("baseline", 0))
+        delta = score - baseline
+        repeat = f" [tried {seen_descs[desc]}x]" if seen_descs.get(desc, 1) > 1 else ""
+        results.append(f"  - {delta:.4f}: \"{desc}\"{repeat} (score={score:.4f})")
+    return results
+
+
+def _current_fp_fn(traces: list[dict]) -> tuple[float | None, float | None, int, int, int, int]:
+    """Return (fp_rate, fn_rate, fp, fn, total_false, total_true) from the most recent trace."""
+    for trace in reversed(traces):
+        detail = trace.get("routing_detail", [])
+        if not detail:
+            continue
+        fp = sum(1 for d in detail if not d.get("correct") and d.get("should_trigger") is False)
+        fn = sum(1 for d in detail if not d.get("correct") and d.get("should_trigger") is True)
+        total_false = sum(1 for d in detail if d.get("should_trigger") is False)
+        total_true = sum(1 for d in detail if d.get("should_trigger") is True)
+        fp_rate = fp / total_false if total_false else 0.0
+        fn_rate = fn / total_true if total_true else 0.0
+        return fp_rate, fn_rate, fp, fn, total_false, total_true
+    return None, None, 0, 0, 0, 0
+
+
+def _recurring_false_positives(traces: list[dict], recent_n: int = 5) -> list[str]:
+    """Return inputs that appear as false positives in the last N traces."""
+    fp_inputs: dict[str, int] = {}
+    for trace in traces[-recent_n:]:
+        for d in trace.get("routing_detail", []):
+            if not d.get("correct") and d.get("should_trigger") is False:
+                inp = d.get("input", "")
+                fp_inputs[inp] = fp_inputs.get(inp, 0) + 1
+    # Only include those appearing in 2+ of the last N traces
+    recurring = [(inp, count) for inp, count in fp_inputs.items() if count >= 2]
+    recurring.sort(key=lambda x: -x[1])
+    return [f"  - \"{inp}\" (seen in {count}/{recent_n} recent traces)" for inp, count in recurring]
+
+
+def generate_milestone(experiment_dir: Path, every: int = 25, force: bool = False) -> bool:
+    """
+    Generate a milestone summary if the iteration count is a multiple of `every` (or force=True).
+
+    Returns True if a milestone was written, False if not needed yet.
+    Exits with code 2 on error.
+    """
+    results_tsv = experiment_dir / "evals" / "results.tsv"
+    traces_dir = experiment_dir / "evals" / "traces"
+
+    if not results_tsv.exists():
+        print(f"ERROR: results.tsv not found at {results_tsv}", file=sys.stderr)
+        sys.exit(2)
+
+    rows = _load_tsv(results_tsv)
+    iter_rows = [r for r in rows if r.get("status") in ("KEEP", "DISCARD")]
+    iteration_count = len(iter_rows)
+
+    if iteration_count == 0:
+        print("No iterations yet — nothing to summarize.")
+        return False
+
+    if not force and (iteration_count % every != 0):
+        print(f"Iteration {iteration_count} is not a multiple of {every} — no milestone needed.")
+        return False
+
+    traces = _load_traces(traces_dir)
+    baseline_rows = [r for r in rows if r.get("status") == "BASELINE"]
+    keep_rows = [r for r in iter_rows if r.get("status") == "KEEP"]
+    discard_rows = [r for r in iter_rows if r.get("status") == "DISCARD"]
+
+    baseline_score = float(baseline_rows[-1]["score"]) if baseline_rows else 0.0
+    current_score = float(rows[-1]["score"]) if rows else 0.0
+    net_delta = current_score - baseline_score
+    acceptance_rate = len(keep_rows) / iteration_count if iteration_count else 0.0
+
+    best_row = max(iter_rows, key=lambda r: float(r["score"])) if iter_rows else None
+    best_score = float(best_row["score"]) if best_row else baseline_score
+    best_desc = best_row.get("description", "baseline") if best_row else "baseline"
+
+    fp_rate, fn_rate, *_ = _current_fp_fn(traces)
+
+    if fp_rate is not None and fn_rate is not None:
+        if fp_rate > fn_rate:
+            dominant = f"PRECISION (fp_rate={fp_rate:.2f}, fn_rate={fn_rate:.2f})"
+            recommendation = "Remove broad keywords or add adversarial <example> blocks. Do NOT add more keywords."
+        elif fn_rate > fp_rate:
+            dominant = f"RECALL (fp_rate={fp_rate:.2f}, fn_rate={fn_rate:.2f})"
+            recommendation = "Add specific trigger phrases. Check 4-char word floor (no 'fix', 'run', 'doc')."
+        elif fp_rate == 0.0 and fn_rate == 0.0:
+            dominant = "NONE — routing is clean"
+            recommendation = "Focus on heuristic structural improvements (examples, body length, references)."
+        else:
+            dominant = f"BOTH precision and recall (fp_rate={fp_rate:.2f}, fn_rate={fn_rate:.2f})"
+            recommendation = "Add specific trigger phrases AND adversarial <example> blocks."
+    else:
+        dominant = "unknown (no trace data)"
+        recommendation = "Run an iteration to generate trace data first."
+
+    milestone_num = iteration_count
+    lines = [
+        f"# Milestone Summary: Iterations 1–{milestone_num}\n",
+        f"\nGenerated: {datetime.now(timezone.utc).isoformat()}\n",
+        f"Experiment: `{experiment_dir}`\n",
+        "\n---\n",
+        "\n## Score Trajectory\n",
+        f"- Baseline:        {baseline_score:.4f}\n",
+        f"- Best achieved:   {best_score:.4f}  (\"{best_desc}\")\n",
+        f"- Current:         {current_score:.4f}\n",
+        f"- Net delta:       {net_delta:+.4f}\n",
+        "\n## KEEP/DISCARD Breakdown\n",
+        f"- {len(keep_rows)} KEEP, {len(discard_rows)} DISCARD  ({acceptance_rate:.0%} acceptance rate)\n",
+    ]
+
+    best_lines = _best_keeps(iter_rows, top_n=3)
+    if best_lines:
+        lines.append("\n## What Worked (top KEEPs by score delta)\n")
+        lines.extend(line + "\n" for line in best_lines)
+
+    worst_lines = _worst_discards(iter_rows, top_n=3)
+    if worst_lines:
+        lines.append("\n## What Did Not Work (worst DISCARDs — do not retry these)\n")
+        lines.extend(line + "\n" for line in worst_lines)
+
+    recurring_fp = _recurring_false_positives(traces)
+    if recurring_fp:
+        lines.append("\n## Recurring False-Positive Inputs (from last 5 traces)\n")
+        lines.extend(line + "\n" for line in recurring_fp)
+
+    lines.append("\n## Dominant Problem\n")
+    lines.append(f"- {dominant}\n")
+    lines.append(f"\n## Recommended Focus for Next {every} Iterations\n")
+    lines.append(f"- {recommendation}\n")
+
+    milestone_filename = f"milestone_{milestone_num:03d}.md"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+    out_path = traces_dir / milestone_filename
+    out_path.write_text("".join(lines))
+    print(f"-> milestone written: {out_path}")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write milestone summary files for long autoresearch runs"
+    )
+    parser.add_argument(
+        "--experiment-dir", required=True,
+        help="Path to the experiment directory (contains evals/ and references/)"
+    )
+    parser.add_argument(
+        "--every", type=int, default=25,
+        help="Write a milestone every N iterations (default: 25)"
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Write a milestone even if iteration count is not a multiple of --every"
+    )
+    args = parser.parse_args()
+
+    experiment_dir = Path(args.experiment_dir).resolve()
+    if not experiment_dir.exists():
+        print(f"ERROR: experiment-dir not found: {experiment_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    generate_milestone(experiment_dir, every=args.every, force=args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
@@ -97,6 +97,7 @@ your-experiment-dir/                           <-- YOUR EXPERIMENT (wherever mak
     traces/              Per-iteration diagnostic JSON — written by evaluate.py each run
       iter_001_KEEP_score0.87.json    mutation diff + per-input routing verdicts
       iter_002_DISCARD_score0.71.json failure_reason for each incorrect routing
+      milestone_025.md   Milestone summary — written every 25 iterations by generate_milestone.py
 ```
 
 ## Setup: Start a New Experiment (4 steps)
@@ -496,6 +497,30 @@ python3 plugins/agent-agentic-os/scripts/evaluate.py \
     --skill <experiment-dir> --baseline --desc "re-baseline after script upgrade"
 git add <experiment-dir>/evals/ && git commit -m "baseline: re-baseline after evaluate.py upgrade"
 ```
+
+### Milestone summaries for long runs (25+ iterations)
+
+For runs exceeding 25 iterations, generate a milestone summary to preserve distant history context:
+
+```bash
+# Write a milestone if iteration count is a multiple of 25 (auto-check)
+python3 plugins/agent-agentic-os/scripts/generate_milestone.py \
+    --experiment-dir <path/to/experiment-dir>
+
+# Force-write a milestone at any iteration count
+python3 plugins/agent-agentic-os/scripts/generate_milestone.py \
+    --experiment-dir <path/to/experiment-dir> --force
+
+# Custom interval (e.g. every 10 iterations)
+python3 plugins/agent-agentic-os/scripts/generate_milestone.py \
+    --experiment-dir <path/to/experiment-dir> --every 10
+```
+
+Output: `evals/traces/milestone_NNN.md` — score trajectory, top KEEPs, worst DISCARDs,
+recurring false-positive inputs, dominant problem type, and recommended focus.
+
+The proposer should read milestone summaries for distant history and raw traces for recent
+iterations. This prevents the loop from losing context on early experiments as trace count grows.
 
 ### Reading traces to diagnose DISCARD iterations
 ```bash


### PR DESCRIPTION
…ess Rec 4)

Writes evals/traces/milestone_NNN.md every 25 iterations (configurable). Sections: score trajectory, top KEEPs, worst DISCARDs with repeat flagging, recurring false-positive inputs from last 5 traces, dominant problem type, and recommended focus. Enables proposer to read distant history without losing context as trace count grows — Meta-Harness proactive summarization pattern (Lee et al., arXiv:2603.28052).

Also documents milestone pattern in os-eval-runner SKILL.md (directory layout + usage commands).

Note: Enhancements 1, 2, 3, and 5 were already implemented in the codebase from a prior session. This commit completes the full set.