### PR TITLE
feat: evolvable Copilot proposer prompt + second-order mutations in e…

### DIFF
--- a/plugins/agent-agentic-os/assets/templates/autoresearch/copilot_proposer_prompt.md.template
+++ b/plugins/agent-agentic-os/assets/templates/autoresearch/copilot_proposer_prompt.md.template
@@ -1,0 +1,29 @@
+# Copilot Proposer Prompt — {{EXPERIMENT_NAME}}
+
+> **This file is a first-class evolvable artifact.**
+> The loop reads this file each iteration and appends the dynamic context (current skill,
+> evals, failure analysis) at call time. Improve this file when the proposals feel off —
+> a better prompt produces better mutations and faster convergence.
+>
+> **After the session:** if this prompt evolved significantly, contribute a refined copy
+> to `plugins/copilot-cli/skills/copilot-cli-agent/references/skill-proposer-prompt.md`
+> so future loops start from a stronger baseline.
+
+---
+
+## System Instructions
+
+You are an expert at optimizing Claude Code SKILL.md routing accuracy.
+
+The skill is evaluated by a headless TF-IDF router that extracts keywords from
+the `description` field in the YAML frontmatter. Routing accuracy improves when:
+- Trigger phrases appear verbatim in the description (exact phrasing matters)
+- False-positive triggers are absent or diluted with specificity
+- The description is concise and concrete — not generic
+
+**CONSTRAINTS (strict):**
+- Minimal edits only — change ≤10 lines per iteration
+- Only modify the `description` field, inline `<example>` trigger phrases, or `<example>` commentary
+- Do NOT add a `keywords:` frontmatter field — it overrides description scanning and breaks the scorer
+- Do NOT rewrite the whole skill — one focused change per iteration
+- Output raw SKILL.md only — no commentary, no markdown fences, no explanation

--- a/plugins/agent-agentic-os/scripts/init_autoresearch.py
+++ b/plugins/agent-agentic-os/scripts/init_autoresearch.py
@@ -96,6 +96,7 @@ def scaffold(experiment_dir: Path, mutation_target: str, plugin_root: Path) -> N
     references_dir = experiment_dir / "references"
     evals_dir = experiment_dir / "evals"
     program_md = references_dir / "program.md"
+    copilot_prompt_md = references_dir / "copilot_proposer_prompt.md"
     evals_json = evals_dir / "evals.json"
     results_tsv = evals_dir / "results.tsv"
 
@@ -120,6 +121,7 @@ def scaffold(experiment_dir: Path, mutation_target: str, plugin_root: Path) -> N
             created.append(str(dest.relative_to(experiment_dir)))
 
     _write_or_skip(program_md, _render(_load_template("program.md.template"), template_vars))
+    _write_or_skip(copilot_prompt_md, _render(_load_template("copilot_proposer_prompt.md.template"), template_vars))
     _write_or_skip(evals_json, _render(_load_template("evals.json.template"), template_vars))
     _write_or_skip(results_tsv, _load_template("results.tsv.template"))  # no vars in header
 

--- a/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-eval-runner/SKILL.md
@@ -153,6 +153,7 @@ You are the OS Quality Assurance (QA) sub-agent. You are a **stateless evaluatio
 | program.md **template** | `skills/os-eval-runner/assets/templates/autoresearch/program.md.template` |
 | evals.json **template** | `skills/os-eval-runner/assets/templates/autoresearch/evals.json.template` |
 | results.tsv **template** | `skills/os-eval-runner/assets/templates/autoresearch/results.tsv.template` |
+| copilot proposer prompt **template** | `skills/os-eval-runner/assets/templates/autoresearch/copilot_proposer_prompt.md.template` |
 
 ### What lives with the target (deployed per experiment, most appropriate location)
 
@@ -162,6 +163,7 @@ with a clear metric. All experiment state deploys alongside the target — not h
 | What | Location |
 |---|---|
 | program.md (rendered from template) | `<experiment-dir>/references/program.md` |
+| copilot proposer prompt (rendered from template) | `<experiment-dir>/references/copilot_proposer_prompt.md` |
 | evals.json (rendered from template) | `<experiment-dir>/evals/evals.json` |
 | results.tsv (loop ledger) | `<experiment-dir>/evals/results.tsv` |
 | .lock.hashes (SHA256 snapshot) | `<experiment-dir>/evals/.lock.hashes` |
@@ -300,18 +302,49 @@ The agent will:
 
    **Step A — Classify failure:** Read the latest row in `<skill>/evals/results.tsv` and the most recent trace file in `<skill>/evals/traces/`. Identify the dominant failure type: `false_positive`, `false_negative`, or `ambiguity`.
 
-   **Step B — Propose via CLI (preferred) or self:** Delegate the mutation to an external CLI proposer for cheap, fast iteration:
+   **Step B — Propose via CLI (preferred) or self:** Delegate the mutation to an external CLI proposer for cheap, fast iteration.
+
+   The proposer prompt lives in `<experiment-dir>/references/copilot_proposer_prompt.md`. Read it each
+   iteration — do not rebuild inline. If the file is missing, scaffold it first:
+   ```bash
+   python3 plugins/agent-agentic-os/scripts/init_autoresearch.py \
+       --experiment-dir <experiment-dir> --mutation-target <filename>
+   ```
+
+   Call pattern:
    ```bash
    cp <skill>/SKILL.md /tmp/current-skill.md
    cp <skill>/evals/evals.json /tmp/current-evals.json
-   copilot -p "You are an expert at optimizing Claude Code SKILL.md routing accuracy.
-   CURRENT SKILL: $(cat /tmp/current-skill.md)
-   EVALS: $(cat /tmp/current-evals.json)
-   ISSUE: <failure_type>: <one-sentence summary>
-   CONSTRAINTS: minimal edits (≤10 lines), fix description/examples only, no 'keywords:' field, output raw SKILL.md only." > /tmp/proposed-skill.md
+   copilot -p "$(cat <experiment-dir>/references/copilot_proposer_prompt.md)
+
+   ---CURRENT SKILL---
+   $(cat /tmp/current-skill.md)
+
+   ---EVAL SUITE---
+   $(cat /tmp/current-evals.json)
+
+   ---FAILURE ANALYSIS---
+   Type: <failure_type>
+   Summary: <one-sentence description of what the last iteration got wrong>" > /tmp/proposed-skill.md
    cp /tmp/proposed-skill.md <skill>/SKILL.md
    ```
    Use `gemini` instead of `copilot` if specified. Fall back to self-proposing only if neither CLI is available. If the proposed file is identical to current, re-prompt with "try a different approach".
+
+   **Step B.1 — Evolve the proposer prompt (second-order mutation):**
+   After 3 consecutive DISCARDs with the same failure type, consider that the *prompt itself* may be
+   the problem — not the skill. Propose one focused improvement to `copilot_proposer_prompt.md`
+   (e.g. add a constraint, clarify the failure pattern, sharpen the output format). Gate it the same
+   way: apply, run the loop, KEEP or revert. A KEEP on a prompt change means future iterations have
+   a stronger proposer.
+
+   Other second-order mutations to consider when the loop stalls:
+   - **`references/program.md`** — if the spec's goal or locked-files list has become ambiguous or
+     misaligned with what the evals actually test, proposing a clarification here can unblock progress.
+   - **`copilot-cli-agent/SKILL.md`** — if the Copilot CLI skill description is missing patterns you
+     rely on, improving it here benefits all future loops that use this proposer.
+
+   Second-order mutations are lower priority than direct skill mutations. Only pursue them when the
+   primary mutation target has stalled (3+ consecutive DISCARDs or diminishing score deltas).
 
    **Step C — Eval gate:**
    ```bash
@@ -461,7 +494,19 @@ For **unattended** (`os-nightly-evolver`) runs: write this commentary to
 `temp/retrospectives/backport_[YYYYMMDD]_iter_NNN.md` and flag for human review
 before applying. Do not auto-apply to master from unattended runs.
 
-**7. Commit to master:**
+**7. Contribute evolved proposer prompt (if improved during the run):**
+
+If `references/copilot_proposer_prompt.md` was mutated and accepted (KEEPed) during the run,
+compare it against the canonical template. If it substantially improved proposal quality, copy it
+to the copilot-cli plugin as a reference example:
+```bash
+cp <lab-experiment-dir>/references/copilot_proposer_prompt.md \
+   plugins/copilot-cli/skills/copilot-cli-agent/references/skill-proposer-prompt.md
+```
+This closes the loop: the prompt that emerged from real eval feedback becomes the new starting
+baseline for future experiments.
+
+**8. Commit to master:**
 ```bash
 cd /path/to/agent-plugins-skills
 git add plugins/<plugin>/...


### PR DESCRIPTION
…val loop

- Add copilot_proposer_prompt.md.template — scaffolded per experiment by init_autoresearch.py, read each iteration instead of rebuilding inline. A better prompt = better proposals = faster convergence.
- Update init_autoresearch.py to deploy the prompt template alongside program.md.
- Update os-eval-runner Mode 1 Step B to read from the file-based prompt, with guidance to evolve it after 3+ consecutive DISCARDs (second-order mutation).
- Add second-order mutation guidance: program.md and copilot-cli SKILL.md as targets when the primary skill stalls.
- Add Stage 7 backport step: contribute evolved proposer prompt back to copilot-cli references/ if it improved during the run.