### PR TITLE
backport: using-git-worktrees description + example tags from eval ro…

### DIFF
--- a/plugins/agent-execution-disciplines/skills/using-git-worktrees/SKILL.md
+++ b/plugins/agent-execution-disciplines/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+description: Use when starting development tasks that need isolation from current workspace or before executing implementation plans - creates independent git worktrees with smart directory selection. Good for simultaneously working on things, or when you need to add a worktree.
 ---
 
 > **Source:** Ported from [obra/superpowers](https://github.com/obra/superpowers) by [Jesse Vincent](https://github.com/obra). Adapted for the `agent-plugins-skills` ecosystem. Original concepts and Iron Laws credit belongs to Jesse.
@@ -168,19 +168,27 @@ Ready to implement <feature-name>
 
 ## Example Workflow
 
-```
+<example>
+I need to work on auth task. Add a git worktree.
+
+[Check .worktrees/ - exists]
+[Determine path: .worktrees/auth]
+[git worktree add .worktrees/auth -b task/auth]
+</example>
+
+<example>
 I'm using the using-git-worktrees skill to set up an isolated workspace.
 
 [Check .worktrees/ - exists]
 [Verify ignored - git check-ignore confirms .worktrees/ is ignored]
-[Create worktree: git worktree add .worktrees/auth -b feature/auth]
+[Add worktree: git worktree add .worktrees/auth -b task/auth]
 [Run npm install]
 [Run npm test - 47 passing]
 
 Worktree ready at /path/to/project/.worktrees/auth
 Tests passing (47 tests, 0 failures)
-Ready to implement auth feature
-```
+Ready to implement auth task
+</example>
 
 ## Red Flags
 


### PR DESCRIPTION
…unds 1-2

Score improvement: 0.7700 → 0.9533 (+0.1833), F1: 0.8235 → 0.9333
Heuristic: 0.70 → 1.0000

- Description: drop 'feature'/'isolated' (false positive triggers on 'feature/auth branch' and 'isolated Docker container'), add 'simultaneously'/'add a worktree' (precise true positive signals)
- Examples: convert fenced code block to <example> XML blocks + add second short example (restored heuristic penalty of -0.30)

Source: test-git-worktrees-eval rounds 1-2, commits 703ef57–5b77193