### PR TITLE
fix: resolve 4 plugin load errors in agent-agentic-os and agent-loops

### DIFF
--- a/plugins/agent-agentic-os/.claude-plugin/plugin.json
+++ b/plugins/agent-agentic-os/.claude-plugin/plugin.json
@@ -27,7 +27,8 @@
     ],
     "agents": [
         "agents/agentic-os-setup.md",
-        "agents/Triple-Loop Retrospective.md",
+        "agents/triple-loop-architect.md",
+        "agents/triple-loop-orchestrator.md",
         "agents/os-health-check.md"
     ],
     "hooks": [

--- a/plugins/agent-loops/.claude-plugin/plugin.json
+++ b/plugins/agent-loops/.claude-plugin/plugin.json
@@ -22,6 +22,17 @@
     "red-team-review"
   ],
   "skills": [
-    "triple-loop-learning"
+    "skills/agent-swarm/SKILL.md",
+    "skills/dual-loop/SKILL.md",
+    "skills/learning-loop/SKILL.md",
+    "skills/orchestrator/SKILL.md",
+    "skills/red-team-review/SKILL.md",
+    "skills/triple-loop-learning/SKILL.md"
+  ],
+  "agents": [
+    "agents/orchestrator.md"
+  ],
+  "hooks": [
+    "hooks/hooks.json"
   ]
 }

--- a/plugins/agent-loops/hooks/hooks.json
+++ b/plugins/agent-loops/hooks/hooks.json
@@ -1,9 +1,16 @@
 {
-    "hooks": [
-        {
-            "type": "Stop",
-            "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete.",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/closure-guard.sh"
-        }
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/skills/orchestrator/scripts/closure-guard.sh",
+            "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete."
+          }
+        ]
+      }
     ]
+  }
 }


### PR DESCRIPTION
## Summary

- **agent-agentic-os** `plugin.json`: removed reference to non-existent `Triple-Loop Retrospective.md`; replaced with actual agent files `triple-loop-architect.md` and `triple-loop-orchestrator.md`
- **agent-loops** `plugin.json`: expanded malformed `"skills": ["triple-loop-learning"]` to all 6 skills with correct `skills/*/SKILL.md` paths; added missing `agents` and `hooks` entries
- **agent-loops** `hooks/hooks.json`: rewrote from wrong flat-array format to correct nested event-keyed format; fixed `closure-guard.sh` path from `hooks/` to `skills/orchestrator/scripts/`

## Test plan

- [ ] Run `/plugin install agent-agentic-os@richfrem-agent-plugins-skills` — should succeed
- [ ] Run `/plugin install agent-loops@richfrem-agent-plugins-skills` — should succeed
- [ ] Run `/reload-plugins` — should report 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)