### PR TITLE
fix: resolve remaining 4 plugin load errors (invalid JSON + missing command)

### DIFF
--- a/plugins/agent-agentic-os/.mcp.json
+++ b/plugins/agent-agentic-os/.mcp.json
@@ -1,1 +1,3 @@
-{\n  "mcpServers": {}\n}\n
+{
+  "mcpServers": {}
+}

--- a/plugins/agent-agentic-os/commands/os-loop.md
+++ b/plugins/agent-agentic-os/commands/os-loop.md
@@ -1,0 +1,8 @@
+---
+name: os-loop
+description: Run a full OS improvement cycle — execute, eval, emit friction events, close with post-run metrics, and trigger a Triple-Loop Retrospective if the friction threshold is crossed.
+---
+# /os-loop Command
+
+Please run the `os-improvement-loop` skill immediately.
+Coordinate a full concurrent improvement cycle: execute tasks, evaluate against the benchmark (KEEP/DISCARD), emit friction events, close with `post_run_metrics`, save the self-assessment survey to retrospectives, persist memory, and trigger the Triple-Loop Retrospective if the friction threshold is crossed.

--- a/plugins/agent-agentic-os/lsp.json
+++ b/plugins/agent-agentic-os/lsp.json
@@ -1,1 +1,3 @@
-{\n  "languageServers": {}\n}\n
+{
+  "languageServers": {}
+}

--- a/plugins/exploration-cycle-plugin/.mcp.json
+++ b/plugins/exploration-cycle-plugin/.mcp.json
@@ -1,1 +1,3 @@
-{\n  "mcpServers": {}\n}\n
+{
+  "mcpServers": {}
+}

--- a/plugins/exploration-cycle-plugin/lsp.json
+++ b/plugins/exploration-cycle-plugin/lsp.json
@@ -1,1 +1,3 @@
-{\n  "languageServers": {}\n}\n
+{
+  "languageServers": {}
+}

--- a/plugins/rsvp-speed-reader/.mcp.json
+++ b/plugins/rsvp-speed-reader/.mcp.json
@@ -1,1 +1,3 @@
-{\n  "mcpServers": {}\n}\n
+{
+  "mcpServers": {}
+}

--- a/plugins/rsvp-speed-reader/lsp.json
+++ b/plugins/rsvp-speed-reader/lsp.json
@@ -1,1 +1,3 @@
-{\n  "languageServers": {}\n}\n
+{
+  "languageServers": {}
+}


### PR DESCRIPTION
## Summary

- **agent-agentic-os**, **exploration-cycle-plugin**, **rsvp-speed-reader**: `lsp.json` and `.mcp.json` stored literal backslash-n characters (`\n`) instead of real newlines — invalid JSON that fails to parse on load
- **agent-agentic-os**: `plugin.json` references `commands/os-loop.md` which did not exist — created stub invoking the `os-improvement-loop` skill

## Root cause

All 6 broken JSON files had the pattern `{\n  "key": {}\n}\n` written as a raw string with escape sequences instead of actual newline bytes. Likely generated by a templating step that forgot to unescape.

## Test plan

- [ ] Merge and run `uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-add richfrem/agent-plugins-skills --all -y`
- [ ] Run `/reload-plugins` — should report **0 errors**
- [ ] Verify `/os-loop` command is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)