### PR TITLE
fix: remove invalid plugin.json arrays, fix hooks formats, fix SKILL.md frontmatter

### DIFF
--- a/plugins/agent-agentic-os/.claude-plugin/plugin.json
+++ b/plugins/agent-agentic-os/.claude-plugin/plugin.json
@@ -15,30 +15,6 @@
         "memory-management",
         "session-management"
     ],
-    "skills": [
-        "skills/os-guide/SKILL.md",
-        "skills/os-init/SKILL.md",
-        "skills/os-memory-manager/SKILL.md",
-        "skills/os-clean-locks/SKILL.md",
-        "skills/os-eval-runner/SKILL.md",
-        "skills/todo-check/SKILL.md",
-        "skills/os-improvement-loop/SKILL.md",
-        "skills/os-improvement-report/SKILL.md"
-    ],
-    "agents": [
-        "agents/agentic-os-setup.md",
-        "agents/triple-loop-architect.md",
-        "agents/triple-loop-orchestrator.md",
-        "agents/os-health-check.md"
-    ],
-    "hooks": [
-        "hooks/hooks.json"
-    ],
-    "commands": [
-        "commands/os-init.md",
-        "commands/os-loop.md",
-        "commands/os-memory.md"
-    ],
     "capabilities": [
         "eval-gate",
         "memory",

--- a/plugins/agent-loops/.claude-plugin/plugin.json
+++ b/plugins/agent-loops/.claude-plugin/plugin.json
@@ -20,19 +20,5 @@
     "orchestration",
     "multi-agent",
     "red-team-review"
-  ],
-  "skills": [
-    "skills/agent-swarm/SKILL.md",
-    "skills/dual-loop/SKILL.md",
-    "skills/learning-loop/SKILL.md",
-    "skills/orchestrator/SKILL.md",
-    "skills/red-team-review/SKILL.md",
-    "skills/triple-loop-learning/SKILL.md"
-  ],
-  "agents": [
-    "agents/orchestrator.md"
-  ],
-  "hooks": [
-    "hooks/hooks.json"
   ]
 }

--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
-  "SessionStart": {
-    "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/SKILL.md
@@ -1,4 +1,3 @@
-# Architectural patterns adapted from obra/superpowers (MIT) https://github.com/obra/superpowers
 ---
 name: subagent-driven-prototyping
 description: >

--- a/plugins/mermaid-to-png/hooks/hooks.json
+++ b/plugins/mermaid-to-png/hooks/hooks.json
@@ -1,3 +1,1 @@
-[
-  // Add plugin hook definitions here
-]
+[]


### PR DESCRIPTION
## Summary

- **agent-agentic-os** + **agent-loops** `plugin.json`: removed explicit `skills/agents/hooks/commands` arrays — Claude Code validator rejects these fields; auto-discovery handles them
- **exploration-cycle-plugin** `hooks/hooks.json`: wrong flat format `{SessionStart:{command}}` → correct nested `{hooks:{SessionStart:[{hooks:[{type:command,...}]}]}}`
- **mermaid-to-png** `hooks/hooks.json`: JS-style `//` comment made file invalid JSON → replaced with empty `[]`
- **exploration-cycle-plugin** `skills/subagent-driven-prototyping/SKILL.md`: attribution comment before `---` frontmatter caused load failure → removed comment line

## Test plan

- [ ] Merge and reinstall: `uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-add richfrem/agent-plugins-skills --all -y`
- [ ] Run `/reload-plugins` → **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)