### PR TITLE
fix: remove banned agents array from rsvp-speed-reader plugin.json

### DIFF
--- a/plugins/rsvp-speed-reader/.claude-plugin/plugin.json
+++ b/plugins/rsvp-speed-reader/.claude-plugin/plugin.json
@@ -7,9 +7,6 @@
     },
     "repository": "https://github.com/richfrem/Project_Sanctuary",
     "architecture": "standalone",
-    "agents": [
-        "rsvp-comprehension-agent"
-    ],
     "license": "MIT",
     "capabilities": [
         "speed-reading",


### PR DESCRIPTION
## Summary
- Removes the `agents` array from `rsvp-speed-reader/.claude-plugin/plugin.json`
- Claude Code validator rejects explicit `agents`/`skills`/`hooks`/`commands` arrays — auto-discovery handles these
- Fixes plugin load error on `/reload-plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)