### PR TITLE
fix: replace symlink stubs with real wrapper scripts for stop hooks

### DIFF
--- a/plugins/agent-agentic-os/hooks/scripts/post_run_metrics.py
+++ b/plugins/agent-agentic-os/hooks/scripts/post_run_metrics.py
@@ -1,1 +1,16 @@
-../../scripts/post_run_metrics.py
+#!/usr/bin/env python3
+# Thin wrapper — delegates to the canonical implementation in scripts/
+import sys
+import os
+from pathlib import Path
+
+# Resolve CLAUDE_PLUGIN_ROOT or fall back to two levels up from this file
+plugin_root = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).parent.parent.parent))
+target = plugin_root / "scripts" / "post_run_metrics.py"
+
+if not target.exists():
+    print(f"ERROR: post_run_metrics.py not found at {target}", file=sys.stderr)
+    sys.exit(1)
+
+# Re-exec the real script so it runs in its own context
+os.execv(sys.executable, [sys.executable, str(target)] + sys.argv[1:])

--- a/plugins/agent-loops/skills/orchestrator/scripts/closure-guard.sh
+++ b/plugins/agent-loops/skills/orchestrator/scripts/closure-guard.sh
@@ -1,1 +1,3 @@
-../../../scripts/closure-guard.sh
+#!/usr/bin/env bash
+# Closure guard stop hook — delegates to closure_guard.py
+exec python3 "${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py" "$@"


### PR DESCRIPTION
Installer (uvx plugin-add) copies symlink stubs as plain text files, breaking hooks that reference them:
- agent-agentic-os hooks/scripts/post_run_metrics.py: was a stub containing a path string -- now a thin Python wrapper that exec's the real script
- agent-loops skills/orchestrator/scripts/closure-guard.sh: was a stub with wrong content and no execute bit -- now a real bash wrapper calling closure_guard.py, with chmod +x applied in source