### PR TITLE
fix: add repository field to exploration-cycle-plugin plugin.json

### DIFF
--- a/plugins/exploration-cycle-plugin/.claude-plugin/plugin.json
+++ b/plugins/exploration-cycle-plugin/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
     "author": {
         "name": "Richard Fremmerlid"
     },
+    "repository": "https://github.com/richfrem/agent-plugins-skills",
     "license": "MIT",
     "keywords": [
         "exploration",


### PR DESCRIPTION
## Summary
- Adds missing `repository` field to `exploration-cycle-plugin/.claude-plugin/plugin.json`
- Without this field the Claude app marketplace cannot match the plugin to its source URL (`github.com/richfrem/agent-plugins-skills`), so it was invisible in the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)