### PR TITLE
fix: add voice-writer and agent-execution-disciplines to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -220,6 +220,22 @@
       "strict": true,
       "category": "integrations",
       "tags": ["rsvp", "speed-reading", "documents", "pdf", "docx"]
+    },
+    {
+      "name": "voice-writer",
+      "description": "Transform AI-generated or over-polished writing into authentic human voice. Supports voice profile calibration so the agent learns your specific style.",
+      "source": "./plugins/voice-writer",
+      "strict": true,
+      "category": "writing",
+      "tags": ["writing", "humanize", "voice", "tone", "ai-patterns", "content"]
+    },
+    {
+      "name": "agent-execution-disciplines",
+      "description": "Core execution disciplines for AI agents: test-driven development, systematic debugging, verification before completion, code review workflows, and git worktree patterns.",
+      "source": "./plugins/agent-execution-disciplines",
+      "strict": true,
+      "category": "agent-infrastructure",
+      "tags": ["tdd", "debugging", "code-review", "git", "worktrees", "verification"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `voice-writer` to marketplace.json (category: writing)
- Adds `agent-execution-disciplines` to marketplace.json (category: agent-infrastructure)

Both plugins were installed locally but missing from the marketplace index, causing "Plugin not found in marketplace richfrem-agent-plugins-skills" errors in Claude Code `/doctor`.

## Test plan
- [ ] Merge and refresh plugin source in Cowork/Claude Code
- [ ] Run `/doctor` — should show 0 "not found in marketplace" errors
- [ ] All 29 plugins load in both CLI and Cowork

🤖 Generated with [Claude Code](https://claude.com/claude-code)