### PR TITLE
fix: add voice-writer to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -220,6 +220,14 @@
       "strict": true,
       "category": "integrations",
       "tags": ["rsvp", "speed-reading", "documents", "pdf", "docx"]
+    },
+    {
+      "name": "voice-writer",
+      "description": "Transform AI-generated or over-polished writing into authentic human voice. Supports voice profile calibration so the agent learns your specific style.",
+      "source": "./plugins/voice-writer",
+      "strict": true,
+      "category": "writing",
+      "tags": ["writing", "humanize", "voice", "tone", "ai-patterns", "content"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `voice-writer` entry to marketplace.json (category: writing)
- Single file change, 8 lines added

This plugin was installed locally but missing from the marketplace index, causing Cowork to not discover it.

## Test plan
- [ ] Merge and check Cowork goes from 26 → 27 plugins
- [ ] Baseline tag `baseline-26-working` available for instant rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)