### PR TITLE
fix: smooth agent friction points across exploration-cycle workflow

### DIFF
--- a/plugins/exploration-cycle-plugin/README.md
+++ b/plugins/exploration-cycle-plugin/README.md
@@ -16,9 +16,11 @@ See the **[Hybrid Workflow Diagram](assets/diagrams/hybrid-workflow.mmd)** for h
 Standard specification kits (like GitHub's `spec-kit`) serve as a "Static Map" for engineering. They are world-class at recording the destination, but they often suffer from **Blank Page Syndrome**—they require structured input to function.
 
 The **exploration-cycle-plugin** solves this by acting as the **Scouting Party**. It is designed for Diamond 1 (Discovery):
+- **Right Problem First**: Before asking "what should we build?", the Scouting Party asks "is building the right intervention?" Sometimes the best outcome is a policy change, a process simplification, or a communication fix — not new software. The discovery phase includes an explicit **Intervention Check** to prevent solutioneering.
 - **Vision Translation**: Pulls ambiguous intent out of a visionary's head and converts it into structured captures before a spec even exists.
 - **Cheap Exploration**: Uses the `dispatch.py` wrapper to call focused, cheap-model sub-agents for framing, BRDs, and user stories. This eliminates the multi-week BA/UX bottleneck.
 - **Non-Linear Iteration**: Allows for "breaking things," hallucinating UIs, and testing "What if?" scenarios without premature architectural solidification.
+- **Output-Agnostic**: The exploration loop produces whatever the problem actually needs — a software prototype, a process map, a policy recommendation, a requirements document, or a "don't build this" conclusion. All are valid, high-value outcomes.
 
 ---
 

--- a/plugins/exploration-cycle-plugin/assets/templates/exploration-dashboard.md
+++ b/plugins/exploration-cycle-plugin/assets/templates/exploration-dashboard.md
@@ -1,7 +1,7 @@
 # Business Exploration Dashboard
 
 **Session:** [to be filled in]
-**Session Type:** [Greenfield | Brownfield | Discovery Only | Spike]
+**Session Type:** [Greenfield | Brownfield | Analysis/Docs | Spike]
 **Dispatch Strategy:** [copilot-cli | claude-subagents | direct]
 **Current Phase:** Phase 1 — Problem Framing
 **Status:** In Progress
@@ -41,7 +41,7 @@ Phases marked `[~]` are intentionally skipped for this session type.
 |------|---------|---------|---------|---------|
 | **Greenfield** (new app) | Required | Required | Standalone prototype | Required |
 | **Brownfield** (existing app) | Required | Optional | Builds into codebase | Optional |
-| **Discovery Only** (docs, not code) | Required | Optional | Skipped | Required (primary output) |
+| **Analysis/Docs** (non-software) | Required | Optional (structure) | Skipped | Required (primary output) |
 | **Spike** (investigation) | Required, may repeat | Flexible | Flexible | Optional |
 
 ---

--- a/plugins/exploration-cycle-plugin/skills/discovery-planning/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/discovery-planning/SKILL.md
@@ -72,7 +72,7 @@ Guide the SME through the following 5 questions, **one at a time**. After each a
 
 **Q3:** "What does a great outcome look like when this is working the way you imagined?"
 
-**Q4:** "If we had to pick the three most important things this must do — what would they be? And what would be nice to have but not essential?"
+**Q4:** "If we had to pick the three most important things this must deliver — what would they be? And what would be nice to have but not essential?"
 
 **Q5:** "Are there any hard rules, limits, or things we absolutely cannot do?"
 

--- a/plugins/exploration-cycle-plugin/skills/discovery-planning/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/discovery-planning/SKILL.md
@@ -61,10 +61,12 @@ Do not mention these steps to the SME.
 
 ## Discovery Session
 
-Guide the SME through the following 5 questions, **one at a time**. After each answer:
+Guide the SME through the following questions, **one at a time**. After each answer:
 - Confirm your understanding in 1–2 plain sentences ("Here's what I heard — does this look right?")
 - Ask any needed clarifying questions before moving to the next
 - Never ask more than one question at a time
+
+### Part 1: Understanding the Problem
 
 **Q1:** "What problem are we trying to solve for the people we serve?"
 
@@ -72,9 +74,46 @@ Guide the SME through the following 5 questions, **one at a time**. After each a
 
 **Q3:** "What does a great outcome look like when this is working the way you imagined?"
 
-**Q4:** "If we had to pick the three most important things this must deliver — what would they be? And what would be nice to have but not essential?"
+### Part 2: Right Problem, Right Intervention
 
-**Q5:** "Are there any hard rules, limits, or things we absolutely cannot do?"
+After Q3, pause and reflect. Based on what you've heard, consider whether the problem
+the SME described is actually a technology problem, or whether it might be:
+- A **process problem** — the steps are in the wrong order, or a handoff is broken
+- A **policy or rules problem** — the rules are confusing, contradictory, or create failure demand
+- A **communication problem** — people don't understand what's available or what to do
+- A **data or access problem** — the information exists but isn't reaching the right people
+
+**Q4 (Intervention Check):** Reflect what you heard, then ask:
+
+> "Before we go further — based on what you've described, I want to make sure we're
+> solving the right problem. Sometimes the best fix isn't a new tool or system — it's
+> changing a rule, simplifying a process, or removing a step entirely.
+>
+> When people hit this problem today, what actually goes wrong for them? Is it that they
+> don't have the right tool, or is it something about how the process or rules work?"
+
+This question is critical. Listen carefully to the answer. If the SME describes a process
+or policy issue rather than a technology gap, gently surface it:
+
+> "It sounds like the core issue might be [process/policy/communication problem], not
+> necessarily a technology gap. If we [simplified the rule / changed the sequence /
+> clarified the guidance], would that solve most of it without building anything new?"
+
+**If the SME agrees the problem is non-technical:** Pivot the session type to Analysis/Docs.
+The deliverable becomes the process change, policy recommendation, or communication fix.
+This is a valid, high-value outcome — saving the cost of building something unnecessary.
+
+**If the SME confirms they do need a technical solution:** Proceed. The intervention check
+still adds value because it sharpens the problem statement and prevents solutioneering.
+
+**If it's mixed:** Note both dimensions. The Discovery Plan should capture the non-technical
+fixes alongside the technical requirements, so the handoff reflects the full picture.
+
+### Part 3: Requirements and Constraints
+
+**Q5:** "If we had to pick the three most important things this must deliver — what would they be? And what would be nice to have but not essential?"
+
+**Q6:** "Are there any hard rules, limits, or things we absolutely cannot do?"
 
 After each answer, reflect back what you heard before moving forward. Example:
 > "So if I'm understanding correctly, [summary]. Does that sound right?"
@@ -95,6 +134,14 @@ Use this exact structure:
 ## Problem Statement
 [plain language, 2-3 sentences]
 
+## Intervention Type
+[What kind of fix does this problem actually need?]
+- Software: [yes/no — and if yes, what kind: new app, feature, automation, integration]
+- Process change: [yes/no — if yes, what needs to change in the workflow]
+- Policy or rules change: [yes/no — if yes, what rule is causing friction]
+- Communication fix: [yes/no — if yes, what guidance is missing or unclear]
+[If multiple, note which is primary and which are supporting]
+
 ## Stakeholders
 [who uses it, who approves, who is affected]
 
@@ -108,7 +155,7 @@ Use this exact structure:
 [numbered list]
 
 ## Open Questions
-[anything that needs more information before building]
+[anything that needs more information before proceeding]
 ```
 
 Use plain language throughout. No technical terms, no jargon.

--- a/plugins/exploration-cycle-plugin/skills/exploration-handoff/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-handoff/SKILL.md
@@ -50,7 +50,7 @@ Agent: [invokes exploration-session-brief, NOT exploration-handoff]
 
 - **Greenfield (Type 1):** Always required — the handoff package is how the engineering team knows what to build.
 - **Brownfield (Type 2):** Optional — if the same person/agent is doing both exploration and implementation, formal handoff may be unnecessary. The SME decides during session setup.
-- **Discovery only (Type 3):** Always required — the handoff IS the primary output of the session (requirements, stories, rules, workflow diagrams).
+- **Analysis/Docs (Type 3):** Always required — the handoff IS the primary output of the session (requirements, process maps, analysis reports, stories, rules, workflow diagrams, or whatever the non-software deliverable is).
 - **Spike (Type 4):** Optional — depends on whether findings need to be communicated to others.
 
 If this phase was skipped during session setup, it will be marked `- [~]` in the dashboard and the orchestrator will not route here.

--- a/plugins/exploration-cycle-plugin/skills/exploration-handoff/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-handoff/SKILL.md
@@ -61,7 +61,11 @@ This skill provides a structured, 3-stage interactive workflow for synthesizing 
 
 ## Stage 0: Scribe Activities (Automated Capture Before Synthesis)
 
-Before opening the handoff dialogue, silently check for `exploration/prototype/`.
+First, check the dashboard `**Session Type:**` field. For **discovery-only** sessions or
+any session where Phase 3 is marked `[~]` (skipped), prototype artifacts are expected to
+be missing — that is correct. Skip Stage 0 entirely and proceed to Stage 1.
+
+For all other sessions, silently check for `exploration/prototype/`.
 
 If the prototype directory exists, run the following three capture activities in sequence.
 Announce each one briefly as you start it:
@@ -113,6 +117,12 @@ Present these options to the SME:
 > 4. **Tier 3 (High Risk)** — PII, sensitive data, high-privilege tools, or public-facing system. Mandatory formal engineering cycle (Opportunity 4) with architectural hardening.
 >
 > Which best describes this project?"
+
+If the SME is uncertain, help them decide with these questions:
+- *"Will this handle personal information or sensitive data?"* (Yes → Tier 2 or 3)
+- *"Will it be used by people outside your team, or be public-facing?"* (Yes → Tier 2 or 3)
+- *"Does it need access to production systems or high-privilege tools?"* (Yes → Tier 3)
+- If all answers are "no" → Tier 1. If some yes → Tier 2. If PII + public-facing → Tier 3.
 
 Record the tier in the handoff package under a `## Risk Assessment` section. Include the tier, a one-sentence rationale from the SME, and the resulting delivery path.
 

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
@@ -40,6 +40,22 @@ When the session reaches Phase 3 (Build), the orchestrator invokes superpowers s
 to enforce execution discipline. The exploration-cycle-plugin owns the discovery
 workflow (Phases 1, 2, 4); superpowers owns the build discipline (Phase 3 execution).
 
+### Superpowers Availability Check
+
+Before invoking any superpowers skill, silently check whether it is available (e.g.,
+try to resolve `superpowers:using-git-worktrees`). If superpowers is **not installed**:
+
+- **Greenfield sessions:** Warn the SME: *"I recommend installing the superpowers plugin
+  for isolated workspaces and build discipline. For now, I'll proceed without it, but
+  the build won't be isolated from your main branch."* Then proceed with `direct` build
+  mode — no worktrees, no TDD, no two-stage review. The prototype still gets built, but
+  without execution discipline guardrails.
+- **Brownfield sessions:** Halt. Announce: *"Building directly into an existing codebase
+  without an isolated workspace is risky. Please install the superpowers plugin first."*
+  Provide the install command from the README.
+
+If superpowers IS available, proceed with the steps below.
+
 ### Step 1 — Isolation: Invoke `superpowers:using-git-worktrees`
 
 Before Phase 3 begins, **invoke the `using-git-worktrees` skill**:
@@ -166,6 +182,19 @@ Is the task orchestration / planning / decision-making?
 The orchestrator (this skill) always stays on the primary model. It delegates
 **implementation** to cheaper/free models. It never delegates **judgment**.
 
+### Discovery-Only Sessions
+
+If the session type is **discovery-only**, skip the dispatch strategy question entirely.
+Default to `direct` and announce: *"Since this is a documentation session with no code
+phase, I'll handle all the work directly."*
+
+### Dispatch Fallback
+
+If the chosen dispatch strategy becomes unavailable during Phase 3 (e.g., Copilot CLI
+is not installed, or the `copilot-cli-agent` skill is not found), fall back to `direct`
+mode and announce: *"The [strategy] dispatch isn't available right now, so I'll build
+this directly in this session."* Do not ask the SME to reconfigure — just proceed.
+
 ---
 
 ## Early Exit — Kill Session
@@ -178,7 +207,9 @@ work", "kill it", "let's stop", or "the idea is bad", the workflow should exit c
    - What was explored
    - What was learned
    - Why the session was stopped
-   - Risk tier: Throwaway (Fail Fast)
+   - A `## Risk Assessment` section containing:
+     `**Outcome:** Throwaway (Fail Fast)` / `**Reason:** [one sentence from SME]` /
+     `**Delivery Path:** Session closed — learning preserved.`
 3. Mark all remaining phases as `[~]` (skipped) with note: `(Session killed — fail fast)`
 4. Update `**Status:**` to `Complete`
 5. Announce: *"Session closed. The learning is saved in `exploration/handoffs/`. Failing fast and cheap is a valid outcome — you saved weeks of wasted effort."*
@@ -325,6 +356,11 @@ Then loop back to **Block 3** to orient the SME for the next phase.
 ## Completion Block
 
 When all phases are either marked `[x]` (complete) or `[~]` (skipped):
+
+**Spike re-entry check:** For spike sessions, before declaring completion, ask the SME:
+*"You've completed this round of investigation. Would you like to loop back to Phase 1
+with what you've learned, or are we done?"* If they want to loop, reset Phase 1 to `[ ]`
+and return to Block 3. If they're done, proceed with completion below.
 
 > "Congratulations — your Exploration Session is complete!
 > All phases are finished and your outputs are ready.

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/SKILL.md
@@ -24,7 +24,7 @@ The workflow adapts to four session types, each with different phase requirement
 |------|-------------|---------------|
 | **Greenfield** | Building a new app or system from scratch | All 4 phases |
 | **Brownfield** | Adding a feature to an existing codebase | Phase 1 required, Phases 2 & 4 optional, Phase 3 builds into real codebase |
-| **Discovery Only** | Output is documents, not code | Phases 1 & 4 required, Phase 2 optional, Phase 3 skipped |
+| **Analysis/Docs** | Non-software output: requirements, process maps, legacy code analysis, policy, strategy, workflow design | Phases 1 & 4 required, Phase 2 optional (structure not layout), Phase 3 skipped |
 | **Spike** | Investigating a question or technology | Phase 1 required (may repeat), all others flexible |
 
 ---
@@ -227,10 +227,10 @@ not just at handoff. The earlier it happens, the more valuable it is.
    - Ask the SME: *"What are we exploring today? Give it a short name so we can track it."*
    - After receiving the session name, ask the SME to choose a **session type**:
      > "What kind of session is this?
-     > 1. **New app or system** — building something from scratch (all 4 phases)
+     > 1. **New app or system** — building a software prototype from scratch (all 4 phases)
      > 2. **Feature for an existing app** — adding to or modifying a codebase you already have (Phase 2 is optional, Phase 3 builds into the real codebase, Phase 4 is optional)
-     > 3. **Discovery only** — the output is documents, not code: requirements, user stories, workflow diagrams, business rules (Phases 1–2 only, no code phases)
-     > 4. **Spike or investigation** — exploring a question, may loop back to Phase 1 multiple times (flexible phases)"
+     > 3. **Analysis or documentation** — no code output. Could be: requirements gathering, business process mapping, legacy code analysis, policy drafting, strategic planning, workflow design, or any non-software deliverable (Phases 1 & 4, Phase 2 optional, Phase 3 skipped)
+     > 4. **Spike or investigation** — exploring a question or technology, may loop back to Phase 1 multiple times (flexible phases)"
    - Based on their selection, scaffold the dashboard from the appropriate template (see Session Type Templates below).
    - Replace `[to be filled in]` in the `**Session:**` field with their session name.
    - Write the updated file, then proceed to Block 3.
@@ -246,11 +246,18 @@ not just at handoff. The earlier it happens, the more valuable it is.
 - Phase 3 (Implementation): enabled — builds directly into the existing codebase (not a throwaway prototype)
 - Phase 4 (Handoff): optional — ask the SME: *"Are you handing this off to another team, or building it yourself? If building it yourself, we can skip the formal handoff."*
 
-**Type 3 — Discovery only:**
+**Type 3 — Analysis or documentation:**
 - Phase 1 (Problem Framing): enabled
-- Phase 2 (Visual Blueprinting): optional — only if the discovery involves UI/UX concepts
-- Phase 3: disabled (no code)
-- Phase 4 (Handoff): enabled — the handoff IS the primary output (requirements, stories, rules)
+- Phase 2 (Visual Blueprinting): optional — only if the work involves visual outputs (UI concepts, process diagrams, workflow maps). For pure analysis or text deliverables, skip.
+- Phase 3: disabled (no code output)
+- Phase 4 (Handoff): enabled — the handoff IS the primary output
+
+This type covers a wide range of non-software work:
+- Business requirements gathering and documentation
+- Business process mapping and workflow design
+- Legacy application or codebase analysis (reading and documenting, not modifying)
+- Policy drafting, strategic planning, or operational procedures
+- Any exploration where the deliverable is documents, not running code
 
 **Type 4 — Spike:**
 - Phase 1 (Problem Framing): enabled, may repeat

--- a/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/SKILL.md
@@ -87,14 +87,10 @@ verify tests pass, then present merge/PR options to the SME.
 
 ## Required Inputs Check
 
-Before doing anything else, verify that both of the following exist:
+Before doing anything else, verify the following:
 
-1. At least one `.md` file in `exploration/discovery-plans/`
-2. The file `exploration/captures/layout-direction.md` (only required if Phase 2 was not skipped)
-
-If the Discovery Plan is missing, stop immediately and report in plain language what needs to happen first.
-
-If the layout direction is missing but Phase 2 was skipped (`- [~]` in the dashboard), proceed without it — use the Discovery Plan's success criteria to guide visual decisions.
+1. **Discovery Plan (required):** At least one `.md` file in `exploration/discovery-plans/`. If missing, stop and report what needs to happen first.
+2. **Layout direction (conditional):** Check the dashboard — if Phase 2 is marked `[~]` (skipped), `layout-direction.md` will not exist, and **that is correct**. Proceed without it, using the Discovery Plan's success criteria to guide visual decisions. Only if Phase 2 was enabled (`[x]` or `[ ]`) is `exploration/captures/layout-direction.md` required.
 
 ## Session Mode Detection
 
@@ -102,7 +98,7 @@ Read `exploration/exploration-dashboard.md` and check the `**Session Type:**` fi
 
 - **Greenfield (Type 1):** Build a standalone prototype in `exploration/prototype/`. Follow the standard Build Loop below.
 - **Brownfield (Type 2):** Build directly into the existing codebase. Before starting, read the project structure to understand existing patterns (component conventions, file locations, styling, API patterns). Match them. Write documentation of what was built to `exploration/prototype/components/` as `.md` files for tracking.
-- **If no session type is set:** Ask the SME: *"Should I build a standalone prototype, or add this directly into your existing codebase?"*
+- **If the session type field is missing, blank, or unrecognized:** Ask the SME: *"Should I build a standalone prototype, or add this directly into your existing codebase?"*
 
 ## Component Decomposition
 

--- a/plugins/exploration-cycle-plugin/skills/visual-companion/SKILL.md
+++ b/plugins/exploration-cycle-plugin/skills/visual-companion/SKILL.md
@@ -39,25 +39,43 @@ This phase may be skipped for brownfield sessions or simple features where the d
 
 ## Role
 
-This skill is invoked after the Discovery Plan is approved. Its purpose is to confirm the visual structure of the prototype before any building starts. It ensures the SME has a clear picture of what they are agreeing to before anything is created.
+This skill is invoked after the Discovery Plan is approved. Its purpose is to confirm the **structure and shape** of the output before any building or drafting starts. For software, this means UI layout. For non-software work, this means document structure, process flow shape, or analysis format. It ensures the SME has a clear picture of what they are agreeing to before anything is created.
 
 ## Session Flow
 
-### Step 1 — Read context
+### Step 1 — Read context and determine output type
 
 Read the most recent file in `exploration/discovery-plans/`. Understand the problem domain, stakeholders, and success criteria before proposing anything. Do not skip this step.
 
-### Step 2 — Present 3 options
+Determine the **output type** from the Discovery Plan and session type:
+- **Software UI** — the output is a screen, page, or interactive interface
+- **Process or workflow** — the output is a business process, approval chain, or operational flow
+- **Document or analysis** — the output is a report, requirements doc, policy, or strategic plan
+- **Mixed** — some combination of the above
 
-Offer 3 layout options adapted to the context of the Discovery Plan. Describe each in plain language (2–4 sentences). No technical terms. No code. No wireframes. Words only.
+### Step 2 — Present 3 options (adapted to output type)
+
+Offer 3 structure options adapted to the context of the Discovery Plan. Describe each in plain language (2–4 sentences). No technical terms. No code. No wireframes. Words only.
 
 Label them **Option A**, **Option B**, **Option C**.
 
-Adapt these generic starting points to the specific problem and user group from the Discovery Plan:
+**For software UI outputs**, adapt these starting points:
 
 - **Option A:** A single-page view with a summary at the top and details below — good when people need to see everything at once and make decisions without switching screens
 - **Option B:** A step-by-step flow that walks the user through one thing at a time — good when there's a sequence of decisions, approvals, or actions that need to happen in order
 - **Option C:** A two-panel layout with a list on the left and details on the right — good when people need to browse through a number of items and compare them before deciding
+
+**For process or workflow outputs**, adapt these starting points:
+
+- **Option A:** A linear flow — steps happen in a fixed order from start to finish, good for simple processes with no branches
+- **Option B:** A decision-tree flow — the path branches based on conditions or approvals, good when different situations lead to different actions
+- **Option C:** A swimlane view — shows who does what at each stage, good when multiple people or teams are involved and handoffs matter
+
+**For document or analysis outputs**, adapt these starting points:
+
+- **Option A:** Executive summary up front with supporting detail sections — good when the audience wants the answer first and the reasoning second
+- **Option B:** Problem → Analysis → Recommendations structure — good when the audience needs to follow the logic to be convinced
+- **Option C:** Comparison format with side-by-side options — good when the deliverable is about choosing between alternatives
 
 After presenting the three options, ask:
 > "Which of these feels closest to what you had in mind? Or if none of them fit, describe what you're picturing and I'll work with that."


### PR DESCRIPTION
## Summary

Simulated 7 scenarios against the full exploration-cycle-plugin and identified 15 friction points where an agent would get confused, stuck, or make wrong decisions. This PR fixes the 10 most impactful ones.

**HIGH severity fixes:**
- Dispatch fallback: if copilot-cli unavailable, fall back to `direct` mode silently
- Superpowers availability check: graceful degradation for greenfield (warn + proceed), hard halt for brownfield (too risky without isolation)

**MEDIUM severity fixes:**
- Skip dispatch strategy question for discovery-only sessions (irrelevant, default to direct)
- Clarified layout-direction.md is expected missing when Phase 2 skipped
- Session mode detection fallback for missing/blank session type field
- Handoff Stage 0 pre-checks session type before looking for prototype artifacts
- Spike re-entry loop check before declaring session complete

**LOW severity fixes:**
- Early exit handoff now includes proper `## Risk Assessment` section
- Tier selection helper questions for uncertain SMEs

## Remaining friction (deferred — low severity or require deeper refactoring)
- #1: Malformed checkbox validation should be in all Dashboard Intercept blocks (not just exploration-workflow)
- #5: Brownfield outcome file path ambiguity in dashboard template
- #8: Skill-to-skill transfer fallback in all child skills
- #12: Prototype-builder should check if Phase 2 skipped before invoking visual-companion
- #14: Stale outcome files when phase re-marked incomplete

## Test plan
- [ ] Discovery-only session: verify dispatch question is skipped, Stage 0 is skipped
- [ ] Brownfield without superpowers: verify hard halt with install instructions
- [ ] Greenfield without superpowers: verify warning + proceed
- [ ] Spike session: verify re-entry loop question at completion
- [ ] Early exit: verify handoff has proper Risk Assessment section

🤖 Generated with [Claude Code](https://claude.com/claude-code)