### PR TITLE
docs: rewrite exploration-cycle-plugin README with full vision and principles

### DIFF
--- a/plugins/exploration-cycle-plugin/README.md
+++ b/plugins/exploration-cycle-plugin/README.md
@@ -1,56 +1,192 @@
 # GenAI Double Diamond: The Operating System for Discovery
 
-The **exploration-cycle-plugin** is a technical implementation of the **GenAI Double Diamond** framework. It provides a non-linear "Scouting Party" for the fuzzy front end of development, bridging the maturity gap between raw intent (The Vibe) and a hardened engineering contract (The Spec).
+The **exploration-cycle-plugin** is a technical implementation of the **GenAI Double Diamond** framework — a structured but adaptive system that puts AI-powered exploration directly into the hands of Subject Matter Experts (SMEs) and Business Area Experts (BAEs).
+
+It bridges the maturity gap between raw intent (*The Vibe*) and a hardened engineering contract (*The Spec*), while recognizing that **not every problem needs software, and not every solution needs formal engineering.**
+
+![The GenAI Double Diamond — Opportunities 3 & 4](assets/resources/design-thinking/infographics/Opportunities-3-4-Prototyping-and-Engineering.png)
+
+**Opportunity 3** (this plugin) is the Discovery Loop: explore, define, prototype, validate.
+**Opportunity 4** is the Engineering Factory: spec-driven development, security hardening, production deployment. The **Handoff & Risk Gate** between them determines whether Opportunity 4 is even needed.
+
+See also: [GenAI Double Diamond Flowchart](assets/diagrams/genai-double-diamond.mmd) | [Hybrid Workflow Diagram](assets/diagrams/hybrid-workflow.mmd)
 
 ---
 
-## 🖼️ Framework Overview
-See the **[GenAI Double Diamond Flowchart](assets/diagrams/genai-double-diamond.mmd)** for a visual representation of the Scouting Party (Diamond 1) and Engineering Factory (Diamond 2) cycle.
+## The Belief: Democratizing AI
 
-See the **[Hybrid Workflow Diagram](assets/diagrams/hybrid-workflow.mmd)** for how the exploration-cycle-plugin and superpowers skills work together. Blue phases are owned by the exploration-cycle-plugin; green phases are powered by superpowers.
+This plugin exists because of a simple belief: **the people closest to the problem should be the ones exploring the solution.**
 
----
+Today, when a business expert has an idea — a process improvement, a new internal tool, a workflow fix — they enter a queue. They wait for a Business Analyst to translate their vision. Then a UX designer interprets it. Then a developer builds what they understood. Each handoff introduces translation errors, delays, and cost. A $5,000 problem gets a $200,000 solution that doesn't quite solve it.
 
-## 🧭 Core Philosophy: The Scouting Party
+The exploration-cycle-plugin changes the equation:
 
-Standard specification kits (like GitHub's `spec-kit`) serve as a "Static Map" for engineering. They are world-class at recording the destination, but they often suffer from **Blank Page Syndrome**—they require structured input to function.
+- **Any SME** can run a structured discovery session with AI guidance — no technical background required
+- **A fleet of cheap AI sub-agents** handles the work that used to require a full BA/UX/dev team: requirements gathering, process documentation, prototyping, user story capture, workflow mapping
+- **The SME stays in control** — the AI asks questions, the human makes decisions. Every phase has a hard gate requiring explicit SME approval before proceeding
+- **The output is whatever the problem actually needs** — a software prototype, a process map, a policy recommendation, a requirements document, or a "don't build this" conclusion. All are valid, high-value outcomes
 
-The **exploration-cycle-plugin** solves this by acting as the **Scouting Party**. It is designed for Diamond 1 (Discovery):
-- **Right Problem First**: Before asking "what should we build?", the Scouting Party asks "is building the right intervention?" Sometimes the best outcome is a policy change, a process simplification, or a communication fix — not new software. The discovery phase includes an explicit **Intervention Check** to prevent solutioneering.
-- **Vision Translation**: Pulls ambiguous intent out of a visionary's head and converts it into structured captures before a spec even exists.
-- **Cheap Exploration**: Uses the `dispatch.py` wrapper to call focused, cheap-model sub-agents for framing, BRDs, and user stories. This eliminates the multi-week BA/UX bottleneck.
-- **Non-Linear Iteration**: Allows for "breaking things," hallucinating UIs, and testing "What if?" scenarios without premature architectural solidification.
-- **Output-Agnostic**: The exploration loop produces whatever the problem actually needs — a software prototype, a process map, a policy recommendation, a requirements document, or a "don't build this" conclusion. All are valid, high-value outcomes.
+The cost of exploration drops from tens of thousands of dollars and weeks of calendar time to a single afternoon conversation. Ideas that would never have been worth a formal project can now be explored, validated, and either shipped or killed — cheaply and safely.
 
 ---
 
-## 🛡️ Safety & Governance: The Rigor Gate
+## Core Principles
 
-Accountability and traceability are not optional in public sector or enterprise GenAI. This plugin mandates a **Risk & Rigor Assessment** (TierGate) during the handoff phase. The exploration does **not** always route to Opportunity 4 (formal engineering). The TierGate produces one of four outcomes:
+### 1. Right Problem First (The Inner Double Diamond)
 
-| Outcome | Risk Profile | Delivery Path |
-| :--- | :--- | :--- |
-| **Throwaway** | Idea proved non-viable during exploration. | Session closed. Learning preserved at near-zero cost. |
-| **Tier 1 (Low)** | Internal utility, limited/no PII. | BAE deploys directly — no formal engineering needed. |
-| **Tier 2 (Moderate)** | Internal data, broader user exposure. | Security review & mandatory Red Teaming before deployment. |
-| **Tier 3 (High)** | PII/Sensitive data, public-facing, high-privilege tools. | **Mandatory** formal engineering cycle (Opportunity 4) with architectural hardening. |
+The most expensive mistake in software development is building the right thing for the wrong problem. The UK's Blue Badge digitization project nearly built a sophisticated document verification portal — until service designers discovered the real problem was confusing policy language. A rewrite of the questions saved millions.
 
-This gate ensures that we remain **Fast by Default, but Safe by Design.** Low-risk tools ship immediately. High-risk systems get the rigor they need. Failed ideas die cheaply.
+Phase 1 of the exploration loop contains its own double diamond:
+
+```
+Phase 1: Discovery Planning
+├── DIVERGE: What's the problem? Who's affected? What does good look like?
+├── CONVERGE: Intervention Check — is this a technology problem, a process
+│   problem, a policy problem, or a communication problem?
+├── DIVERGE: What must the solution deliver? What are the constraints?
+└── CONVERGE: Discovery Plan — approved by SME before anything else happens
+```
+
+The **Intervention Check** (Q4) is the moment where the Scouting Party earns its keep. It explicitly asks: *"Is building something the right intervention here, or could this be solved by changing a rule, simplifying a process, or removing a step entirely?"*
+
+If the answer is "don't build" — that's a success, not a failure. You discovered it in 20 minutes instead of 6 months.
+
+### 2. Output-Agnostic
+
+Not every exploration produces software. The plugin adapts to four session types:
+
+| Type | What it produces | When to use |
+|------|-----------------|-------------|
+| **Greenfield** | Working prototype + handoff package | Building a new app or system from scratch |
+| **Brownfield** | Features built into existing codebase | Adding to or modifying an existing application |
+| **Analysis/Docs** | Requirements, process maps, policies, analysis | Non-software deliverables: legacy code analysis, workflow design, strategic planning, business process documentation |
+| **Spike** | Investigation findings, may loop | Exploring a question or technology, flexible phases |
+
+Phase 2 (Visual Blueprinting) adapts too — presenting UI layouts for software, process flow structures for workflows, or document structures for reports and analysis. The visual-companion skill reads the Discovery Plan and proposes options appropriate to the output type.
+
+### 3. Quality Without Overhead
+
+Even prototypes need validation — the prototype is the **evidence** that the exploration captured the right thing. If the prototype doesn't match the Discovery Plan, the SME reviews the wrong behavior, the handoff describes the wrong system, and the engineering team builds from a flawed spec.
+
+But validation doesn't mean heavyweight process. The execution discipline scales with the session:
+- **Greenfield/Brownfield**: Git worktree isolation, TDD per component, two-stage code review (plan alignment + quality), structured branch finishing
+- **Analysis/Docs**: Outputs validated against Discovery Plan requirements, checked for completeness and contradictions
+- **Spike**: Flexible — the SME decides what validation is appropriate as the investigation unfolds
+
+### 4. Cheap Exploration, Smart Dispatch
+
+The plugin uses a tiered dispatch strategy to minimize token cost without sacrificing quality:
+
+| Dispatch Strategy | Simple/Mechanical Tasks | Complex/Multi-File Tasks | Orchestration/Planning |
+|---|---|---|---|
+| **Copilot CLI** (recommended if available) | `gpt-5-mini` — free, unlimited | `claude-sonnet` — 1 premium request, batched dense | Current model (orchestrator) |
+| **Claude Sub-agents** | `haiku` — cheapest | `sonnet` — mid-tier | Current model (orchestrator) |
+| **Direct** | Inline | Inline | Inline |
+
+The key insight: Copilot Pro charges per **request**, not per token. One dense prompt with 7 file specifications costs the same as one small prompt. The orchestrator (this skill, running on the primary model) never delegates judgment — only implementation.
+
+### 5. Fast by Default, Safe by Design
+
+Not everything needs a formal engineering cycle. The **TierGate** (Risk & Rigor Assessment) during handoff determines the proportional delivery path:
+
+| Outcome | Risk Profile | What Happens Next |
+|---|---|---|
+| **Throwaway** | Idea proved non-viable during exploration | Session closed. Learning preserved at near-zero cost. |
+| **Tier 1 (Low)** | Internal utility, limited/no PII | BAE deploys directly — no formal engineering needed |
+| **Tier 2 (Moderate)** | Internal data, broader user exposure | Security review & mandatory Red Teaming before deployment |
+| **Tier 3 (High)** | PII/Sensitive data, public-facing, high-privilege | Mandatory formal engineering cycle (Opportunity 4) with architectural hardening |
+
+A low-risk internal tool ships immediately. A high-risk public system gets the rigor it needs. A failed idea dies cheaply. The gate is proportional, not bureaucratic — a few conversational questions, not a compliance form.
 
 ---
 
-## 🔄 Bidirectional Re-Entry: Navigating the Unknown
+## The Exploration Loop
 
-Engineering is rarely linear. A core design feature of this plugin is the **Bidirectional Re-Entry loop**. 
+The plugin orchestrates a 4-phase discovery loop, managed by the `exploration-workflow` skill via a conversational dashboard. Phases can be skipped based on session type.
 
-When Diamond 2 (Execution) uncovers an "unknown unknown"—unresolved ambiguity in the spec, a missed edge case in the data model, or a shift in vision—the `planning-doc-agent` triggers a re-entry cycle back to Diamond 1. This allows the team to resolve the vision gap in a low-cost discovery mode without losing momentum in the production factory.
+### Phase 1: Problem Framing (`discovery-planning`)
+The inner double diamond. Five guided questions, one at a time, with an Intervention Check that asks whether software is even the right answer. Produces an SME-approved Discovery Plan. **Hard gate: nothing proceeds without explicit SME approval.**
+
+### Phase 2: Visual Blueprinting (`visual-companion`)
+Confirms the structure and shape of the output before any building starts. For software: UI layouts. For workflows: process flow structures. For documents: report structures. Optional for brownfield and analysis sessions.
+
+### Phase 3: Build (`subagent-driven-prototyping`)
+Component-by-component construction with per-component validation. Brownfield sessions build directly into the existing codebase. Greenfield sessions produce standalone prototypes. Powered by superpowers execution discipline (worktrees, TDD, code review). Skipped for analysis/docs sessions.
+
+### Phase 4: Handoff & Specs (`exploration-handoff`)
+Automated capture of business requirements, user stories, and workflow diagrams, synthesized into a structured handoff package. Includes the TierGate risk assessment that determines the delivery path. Optional for brownfield self-builds.
+
+### Early Exit
+At any phase, if the SME says "this isn't going to work" — the session closes cleanly, preserving what was learned. Failing fast and cheap is a valid, valuable outcome.
 
 ---
 
-## 🏗️ Technical Architecture
+## Bidirectional Re-Entry
+
+Engineering is rarely linear. When Opportunity 4 (Execution) uncovers an "unknown unknown" — unresolved ambiguity, a missed edge case, a shift in vision — the `planning-doc-agent` triggers a re-entry cycle back to Opportunity 3. The team resolves the gap in low-cost discovery mode without losing momentum in the production factory.
+
+---
+
+## Built on `obra/superpowers`
+
+The `exploration-cycle-plugin` is built on top of [**obra/superpowers**](https://github.com/obra/superpowers), an open-source agentic harness by Jesse Vincent (obra). Superpowers is a **required runtime dependency** — the execution discipline skills are invoked directly during Phase 3.
+
+### What we borrow (and why it's brilliant)
+
+Superpowers provides world-class execution discipline for AI-assisted development. Its patterns for context isolation, verification, and structured workflows are the foundation this plugin builds on:
+
+| Pattern | Superpowers Source | How We Use It |
+|---|---|---|
+| `<HARD-GATE>` execution block | `brainstorming` skill | `discovery-planning` — SME approval gate before anything proceeds |
+| Blank-slate context isolation | `subagent-driven-development` | `subagent-driven-prototyping` — fresh sub-agent per component |
+| Two-stage verification | Spec + Quality reviewers | Plan alignment check + Quality check per component |
+| Git worktree isolation | `using-git-worktrees` | Isolated workspace before any build work |
+| TDD cycle | `test-driven-development` | Verification that each component matches the Discovery Plan |
+| Branch finishing | `finishing-a-development-branch` | Structured merge/PR/cleanup flow |
+| Model tiering | Cheap → standard → capable | 3 dispatch strategies with decision tree per task complexity |
+| Linguistic Detox | Jargon policing | Plain language enforcement across all SME-facing agents |
+
+### What we add
+
+The exploration-cycle-plugin extends superpowers into territory it wasn't designed for — the fuzzy front end before a spec exists:
+
+| Capability | What It Does | Why Superpowers Doesn't Cover It |
+|---|---|---|
+| **Discovery Planning with Intervention Check** | Guided problem framing that asks whether software is even the right answer | Superpowers assumes the spec already exists — it doesn't question whether to build |
+| **Session Type Adaptation** | Greenfield, brownfield, analysis/docs, spike — each with different phase requirements | Superpowers has one workflow for all development |
+| **Visual Blueprinting** | Adaptive structure confirmation — UI layouts, process flows, or document structures | Superpowers doesn't address pre-build design confirmation |
+| **Output-Agnostic Exploration** | Non-software deliverables: process maps, policy recommendations, business analysis | Superpowers is code-focused |
+| **TierGate with Four Outcomes** | Risk assessment that routes to direct deployment, security review, formal engineering, or throwaway | Superpowers assumes all work enters the engineering pipeline |
+| **Copilot CLI Dispatch** | Token-optimized orchestration using free/cheap models for mechanical tasks | Superpowers uses Claude model tiering only |
+| **SME-First Language** | Every user-facing message in plain language — "build" not "scaffold", "check" not "validate" | Superpowers speaks to developers |
+| **Early Exit / Fail Fast** | Clean session kill at any phase, preserving learning | Superpowers doesn't model session abandonment |
+| **Bidirectional Re-Entry** | Loop from engineering back to discovery when unknowns surface | Superpowers is forward-only |
+
+### The relationship
+
+```
+exploration-cycle-plugin              obra/superpowers
+============================          ================
+Owns the WHAT                         Owns the HOW
+(discovery, framing, intervention     (isolation, dispatch, testing,
+ check, layout, handoff, risk gate)    review, finishing)
+
+Phase 1: Problem Framing         →   (standalone)
+Phase 2: Visual Blueprinting     →   (standalone)
+Phase 3: Build                   →   uses: worktrees, sub-agent dispatch, TDD, code review
+Phase 4: Handoff                 →   (standalone)
+```
+
+**superpowers is licensed under the MIT License.** Full text: https://github.com/obra/superpowers/blob/main/LICENSE
+
+The `exploration-cycle-plugin` is independently authored and not affiliated with or endorsed by obra/superpowers.
+
+---
+
+## Technical Architecture
 
 ### CLI Invocation Pattern (Cheap Sub-Agents)
-To maintain the "Cheap Exploration" economic advantage, all documentation sub-agents are invoked via a dedicated `dispatch.py` wrapper. This avoids context truncation and ensures precise subprocess execution.
+All documentation sub-agents are invoked via a dedicated `dispatch.py` wrapper for cost efficiency and context isolation:
 
 ```bash
 python3 ./skills/exploration-workflow/scripts/dispatch.py \
@@ -63,85 +199,39 @@ python3 ./skills/exploration-workflow/scripts/dispatch.py \
 ### Directory Structure
 ```text
 exploration-cycle-plugin/
-├── OVERVIEW.md                     # GenAI Double Diamond framework overview
-├── README.md                       # Entry point and philosophy
+├── README.md                       # This file — vision, principles, architecture
+├── OVERVIEW.md                     # Deeper conceptual dive into the GenAI Double Diamond
+├── BAE-start-guide.md              # Quick start guide for Business Area Experts
 ├── agents/                         # Vision Translators and Scribes
-├── assets/diagrams/                # Technical and philosophical flowcharts
+├── assets/
+│   ├── diagrams/                   # Technical flowcharts (Mermaid)
+│   ├── resources/design-thinking/  # Framework infographics and references
+│   └── templates/                  # Dashboard and session templates
 ├── references/                     # Architectural patterns (Dual-Loop, Learning-Loop)
-├── skills/                         # Technical capabilities
+├── skills/
+│   ├── discovery-planning/         # Phase 1: Problem framing with Intervention Check
+│   ├── visual-companion/           # Phase 2: Adaptive structure confirmation
+│   ├── prototype-builder/          # Phase 3 coordinator: orchestrates build cycle
+│   ├── subagent-driven-prototyping/# Phase 3 builder: component-by-component construction
+│   ├── exploration-handoff/        # Phase 4: Synthesis, TierGate, and handoff packaging
+│   ├── exploration-workflow/       # Orchestrator: state machine managing the full loop
 │   ├── business-requirements-capture/
 │   ├── business-workflow-doc/
-│   ├── discovery-planning/         # NEW: HARD-GATE SME discovery session
-│   ├── exploration-handoff/
 │   ├── exploration-optimizer/
 │   ├── exploration-session-brief/
-│   ├── exploration-workflow/
-│   ├── prototype-builder/          # NEW: orchestrates full prototype build cycle
-│   ├── subagent-driven-prototyping/ # NEW: component-by-component builder
-│   ├── user-story-capture/
-│   └── visual-companion/           # NEW: layout direction before building
+│   └── user-story-capture/
 └── requirements.in                 # Python dependencies
 ```
-
----
-
-## 🔌 Required Dependency: `orba/superpowers`
-
-The `exploration-cycle-plugin` **requires** the [orba/superpowers](https://github.com/obra/superpowers) plugin to be installed. The exploration workflow does not replace superpowers — it **augments and leverages** its execution discipline skills during Phase 3 (Build).
-
-### Why use execution discipline on prototypes?
-
-The prototype is the **evidence** that the exploration captured the right thing. If the
-prototype doesn't match the Discovery Plan, the SME reviews the wrong behavior, the
-handoff describes the wrong system, and the engineering team builds from a flawed spec.
-
-Execution discipline during Phase 3 isn't about production code quality — it's about
-**exploration accuracy**. Sub-agents keep components focused. Validation checks verify
-each component against the plan. Code review catches drift before the SME sees it.
-Even a prototype that will be thrown away after handoff must be verified.
-
-### What superpowers provides (used by this plugin)
-
-| Superpowers Skill | Used During | Exploration Purpose |
-|---|---|---|
-| `using-git-worktrees` | Phase 3 start | Isolated workspace — don't break the existing app while exploring |
-| `subagent-driven-development` | Phase 3 build loop | Fresh sub-agent per component — context isolation keeps each piece focused |
-| `test-driven-development` | Phase 3 build loop | Verify each component meets a Discovery Plan requirement |
-| `requesting-code-review` | Phase 3 review | Plan alignment check — does this demonstrate what the SME asked for? |
-| `finishing-a-development-branch` | Phase 3 completion | Structured merge/PR/cleanup flow |
-
-### How the relationship works
-
-```
-exploration-cycle-plugin          orba/superpowers
-========================          ================
-Phase 1: Problem Framing    →    (standalone — no superpowers needed)
-Phase 2: Visual Blueprinting →   (standalone — no superpowers needed)
-Phase 3: Build               →   uses: worktrees, sub-agent dispatch, TDD, code review
-Phase 4: Handoff             →    (standalone — no superpowers needed)
-```
-
-The exploration-cycle-plugin owns the **what** (discovery, framing, layout, handoff).
-Superpowers owns the **how** (isolation, dispatch, testing, review, finishing).
 
 ### Installation
 
 **Claude Code (recommended):**
 ```bash
-# Install superpowers first
+# Install superpowers first (required dependency)
 claude mcp add-plugin orba/superpowers
 
 # Then install exploration-cycle-plugin
 claude mcp add-plugin richfrem/agent-plugins-skills --path plugins/exploration-cycle-plugin
-```
-
-**Plugin Manager (if using agent-plugins-skills marketplace):**
-```bash
-# Install superpowers
-uvx --from git+https://github.com/obra/superpowers plugin-install orba/superpowers
-
-# Install exploration-cycle-plugin
-uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-install exploration-cycle-plugin
 ```
 
 **Manual installation:**
@@ -149,7 +239,7 @@ uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-install e
 2. Clone or symlink `plugins/exploration-cycle-plugin` from this repo into your plugins directory
 3. Ensure both are discoverable by your agent harness (Claude Code, Copilot CLI, Gemini CLI, etc.)
 
-**Verification:** After installation, confirm both plugins are loaded:
+**Verification:**
 ```bash
 # In Claude Code
 /skills  # should list both exploration-workflow and using-git-worktrees
@@ -157,49 +247,12 @@ uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-install e
 
 ---
 
-## 📜 Attribution & License
+## Getting Started
 
-### Architectural Foundation: `obra/superpowers`
+**For Business Area Experts:** See the [BAE Quick Start Guide](./BAE-start-guide.md) for a plain-language walkthrough.
 
-The `exploration-cycle-plugin` is built on top of
-[**obra/superpowers**](https://github.com/obra/superpowers), an open-source
-agentic harness by Jesse Vincent (obra). Superpowers is a **required runtime
-dependency**, not just an inspiration — the execution discipline skills are
-invoked directly during Phase 3.
+**For AI agents:** The canonical entry point is the `exploration-workflow` skill. Say "start an exploration" or "let's explore this idea" to begin.
 
-Patterns adapted from superpowers:
+**Recommended first-time flow:** Start with the `intake-agent` for an interactive onboarding conversation, then let `exploration-workflow` guide the rest.
 
-| Pattern | Superpowers Source | Exploration-Cycle Adaptation |
-|---|---|---|
-| `<HARD-GATE>` execution block | `brainstorming` skill | `discovery-planning` skill — SME approval gate |
-| Blank-slate context isolation | `subagent-driven-development` | `subagent-driven-prototyping` — fresh sub-agent per component |
-| Two-stage verification | Spec + Quality reviewers | Plan alignment check + Quality check |
-| Git worktree isolation | `using-git-worktrees` | Referenced directly — isolated workspace before build |
-| TDD cycle | `test-driven-development` | Adapted: evals for skills, tests for code, validation for docs |
-| Branch finishing | `finishing-a-development-branch` | Referenced directly — merge/PR/cleanup flow |
-| Model tiering | Cheap→standard→capable | 3 dispatch strategies: copilot-cli, claude-subagents, direct |
-| Linguistic Detox (persona scan) | Jargon policing | SME language enforcement across all agents |
-
-**superpowers is licensed under the MIT License.**
-Full text: https://github.com/obra/superpowers/blob/main/LICENSE
-
-The `exploration-cycle-plugin` is independently authored and not affiliated with or endorsed by obra/superpowers.
-
----
-
-*See [OVERVIEW.md](OVERVIEW.md) for a deeper conceptual dive into the GenAI Double Diamond.*
-
-## BAE Start Guide
-
-A concise how-to for Business Area Experts (BAEs) has been added: `plugins/exploration-cycle-plugin/BAE-start-guide.md`.
-Recommended entrypoint for BAEs: `intake-agent` (interactive). For CLI-driven automation, use `exploration-workflow` as described in the guide.
-
-
-### BAE Start Guide & Diagram
-
-- BAE Start Guide: [BAE Quick Start — Guided Exploration Process](./BAE-start-guide.md)
-
-High-level process diagram:
-
-![High-level process](assets/diagrams/high-level-process.png)
-
+*See [OVERVIEW.md](OVERVIEW.md) for a deeper conceptual dive into the GenAI Double Diamond framework.*

--- a/plugins/exploration-cycle-plugin/skills/discovery-planning/discovery-planning-agent.md
+++ b/plugins/exploration-cycle-plugin/skills/discovery-planning/discovery-planning-agent.md
@@ -1,0 +1,1 @@
+../../agents/discovery-planning-agent.md

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/assets/Opportunities-3-4-Prototyping-and-Engineering.png
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/assets/Opportunities-3-4-Prototyping-and-Engineering.png
@@ -1,0 +1,1 @@
+../../../assets/resources/design-thinking/infographics/Opportunities-3-4-Prototyping-and-Engineering.png

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/exploration-dashboard-template.md
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/exploration-dashboard-template.md
@@ -1,0 +1,1 @@
+../../assets/templates/exploration-dashboard.md

--- a/plugins/exploration-cycle-plugin/skills/exploration-workflow/hybrid-workflow.mmd
+++ b/plugins/exploration-cycle-plugin/skills/exploration-workflow/hybrid-workflow.mmd
@@ -1,0 +1,1 @@
+../../assets/diagrams/hybrid-workflow.mmd

--- a/plugins/exploration-cycle-plugin/skills/prototype-builder/prototype-builder-agent.md
+++ b/plugins/exploration-cycle-plugin/skills/prototype-builder/prototype-builder-agent.md
@@ -1,0 +1,1 @@
+../../agents/prototype-builder-agent.md

--- a/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/prototype-companion-agent.md
+++ b/plugins/exploration-cycle-plugin/skills/subagent-driven-prototyping/prototype-companion-agent.md
@@ -1,0 +1,1 @@
+../../agents/prototype-companion-agent.md


### PR DESCRIPTION
## Summary

Complete rewrite of the exploration-cycle-plugin README to reflect the evolved design philosophy after today's session of improvements.

- **Foundational infographic** (Opportunities 3 & 4) linked near the top
- **"The Belief: Democratizing AI"** — the why: giving SMEs/BAEs world-class AI sub-agents to explore and prototype without BA/UX/dev teams
- **5 Core Principles**: Right Problem First (inner double diamond), Output-Agnostic, Quality Without Overhead, Cheap Exploration/Smart Dispatch, Fast by Default/Safe by Design
- **Inner double diamond** diagram in Phase 1 with the Intervention Check
- **"What we borrow" and "What we add"** tables — full attribution to obra/superpowers as foundation, with clear articulation of significant extensions
- **TierGate with 4 outcomes** — not everything goes to Opportunity 4
- **Dispatch strategy table** — copilot-cli, claude-subagents, direct
- Streamlined installation and getting started sections

## Test plan

- [ ] Verify infographic renders correctly on GitHub
- [ ] Verify all internal links resolve (diagrams, BAE guide, OVERVIEW.md)
- [ ] Read through as a first-time visitor — does the vision come through?

🤖 Generated with [Claude Code](https://claude.com/claude-code)