### PR TITLE
docs: clarify plugin agent placement is flat .md (not subdirectory li…

### DIFF
--- a/plugins/agent-scaffolders/skills/create-sub-agent/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-sub-agent/SKILL.md
@@ -28,6 +28,14 @@ Agent `.md` file with complete YAML frontmatter (name, description with `<exampl
 model, maxTokens, color, permissions.allowedTools, permissions.deny) and a second-person
 system prompt targeting 500-3,000 characters.
 
+## Placement Rules
+
+**Plugin agents**: flat `.md` file — `plugins/<plugin-name>/agents/<agent-name>.md`
+- **No subdirectory.** Skills use `skills/<name>/SKILL.md` subdirectory format, but agents do NOT.
+- Confirmed against Anthropic official plugins (`feature-dev`, `code-simplifier`, `hookify`).
+
+**Local/project agents**: `.claude/agents/<agent-name>.md` (also flat, no subdirectory).
+
 ## Edge Cases
 
 - If `$ARGUMENTS` is empty: conduct the full Phase 1 design interview — do not pre-fill

--- a/plugins/agent-skill-open-specifications/references/sub-agents.md
+++ b/plugins/agent-skill-open-specifications/references/sub-agents.md
@@ -25,12 +25,34 @@ The frontmatter defines the metadata and bounds of the subagent:
 - `memory`: Persistent memory scope (`user`, `project`, `local`) forming a `$MEMORY_DIR/MEMORY.md` directory across sessions.
 - `hooks`: Component-scoped [Hooks](hooks.md) running explicitly for this agent's lifecycle (e.g., `PreToolUse`, `SubagentStop`).
 
+## Placement: Plugin agents vs local agents
+
+**Plugin agents** (in an installed plugin) live as **flat `.md` files** inside the plugin's `agents/` directory:
+```
+plugins/<plugin-name>/agents/<agent-name>.md   ✓ correct
+plugins/<plugin-name>/agents/<agent-name>/AGENT.md  ✗ wrong — no subdirectory
+```
+
+This is the **opposite** of how skills are structured. Skills require a subdirectory + `SKILL.md` filename (`skills/<name>/SKILL.md`), but agents are flat files.
+
+**Local project agents** live in `.claude/agents/<agent-name>.md` (also flat).
+
+Confirmed by inspecting Anthropic's official plugin examples: `feature-dev`, `code-simplifier`, `hookify`, `agent-sdk-dev` all use flat `.md` agent files.
+
+## tools field format
+
+The `tools` allowlist can be written as either a comma-separated string or a JSON array:
+```yaml
+tools: Read, Glob, Grep           # string form
+tools: ["Read", "Glob", "Grep"]   # array form (also valid)
+```
+
 ## Scope & Precedence
 When multiple subagents share the same name, they resolve in an ordered priority:
 1. **CLI Flag** (`--agents '{...json...}'`)
-2. **Project** (`.claude/skills/`)
-3. **User Local** (`~/.claude/skills/`)
-4. **Plugin** (located in the enabled plugin's `agents/` root).
+2. **Project** (`.claude/agents/`)
+3. **User Local** (`~/.claude/agents/`)
+4. **Plugin** (flat `.md` files in the enabled plugin's `agents/` directory).
 
 ## Foreground vs. Background execution
 - **Foreground:** Subagent blocks the main conversation, passing through interactive permission and `AskUserQuestion` prompts.


### PR DESCRIPTION
…ke skills)

Plugin agents live at agents/<name>.md (flat), not agents/<name>/AGENT.md. Skills use subdirectory format (skills/<name>/SKILL.md) but agents do not. Add tools field format examples and corrected scope/precedence paths.