### PR TITLE
fix(context-bundler): guard against empty path entries in bundle scripts

### DIFF
--- a/plugins/context-bundler/scripts/bundle.py
+++ b/plugins/context-bundler/scripts/bundle.py
@@ -78,8 +78,17 @@ def bundle_files(manifest_path: Path, output_path: Path) -> None:
     print("🔍 Resolving files and calculating token budgets...")
 
     for entry in files:
-        path_str = entry.get('path', '')
+        path_str = entry.get('path', '').strip()
         note = entry.get('note', '')
+
+        # Guard: skip entries with empty/blank paths — likely a manifest key typo
+        # (e.g. "path:" instead of "path"). Without this, project_root / '' resolves
+        # to the project root dir and rglob crawls the entire workspace.
+        if not path_str:
+            print(f"⚠️  Skipping manifest entry with empty 'path' — possible key typo: {entry}")
+            resolved_files.append({'path': '(empty path — skipped)', 'note': str(entry), 'missing': True})
+            continue
+
         actual_path = project_root / path_str
 
         if actual_path.is_dir():

--- a/plugins/context-bundler/scripts/bundle_zip.py
+++ b/plugins/context-bundler/scripts/bundle_zip.py
@@ -77,8 +77,17 @@ def generate_zip_bundle(manifest_path: Path, output_path: Path) -> None:
     print("🔍 Scanning directories and estimating tokens...")
 
     for entry in files:
-        path_str = entry.get('path', '')
+        path_str = entry.get('path', '').strip()
         note = entry.get('note', '')
+
+        # Guard: skip entries with empty/blank paths — likely a manifest key typo
+        # (e.g. "path:" instead of "path"). Without this, project_root / '' resolves
+        # to the project root dir and rglob crawls the entire workspace.
+        if not path_str:
+            print(f"⚠️  Skipping manifest entry with empty 'path' — possible key typo: {entry}")
+            resolved_files.append({'path': '(empty path — skipped)', 'note': str(entry), 'missing': True})
+            continue
+
         actual_path = project_root / path_str
 
         if actual_path.is_dir():


### PR DESCRIPTION
When a manifest JSON has a key typo like "path:" instead of "path", entry.get('path', '') returns an empty string. Path.cwd() / '' resolves to the project root directory, causing rglob('*') to crawl the entire workspace and produce a multi-million token output bundle.

Fix: strip whitespace and skip the entry with a clear warning if path_str is empty after the get(). Applied to both bundle.py and bundle_zip.py.

Root cause discovered via plugins/obsidian-integration bundle run where the file-manifest.json had 'path:' keys (colon embedded in key name) for two additional file entries.