### PR TITLE
feat(plugins): add hermes-native plugin.yaml for all 23 plugins

### DIFF
--- a/plugins/adr-manager/plugin.yaml
+++ b/plugins/adr-manager/plugin.yaml
@@ -1,0 +1,13 @@
+name: adr-manager
+version: 2.0.0
+description: "ADR management — generates architecture decision records, documents design rationale, and maintains the decision log."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - adr_manager
+skills:
+  - adr-management

--- a/plugins/agent-agentic-os/plugin.yaml
+++ b/plugins/agent-agentic-os/plugin.yaml
@@ -1,0 +1,25 @@
+name: agent-agentic-os
+version: 1.6.0
+description: "Opinionated learning layer above Claude Code — structured memory hierarchy, continuous improvement loop, multi-agent event bus coordination, and eval-gated skill improvement."
+author: Richard Fremmerlid
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - eval_runner
+  - experiment_log
+  - init_agentic_os
+skills:
+  - optimize-agent-instructions
+  - os-clean-locks
+  - os-eval-backport
+  - os-eval-lab-setup
+  - os-eval-runner
+  - os-guide
+  - os-improvement-loop
+  - os-improvement-report
+  - os-init
+  - os-memory-manager
+  - todo-check

--- a/plugins/agent-loops/plugin.yaml
+++ b/plugins/agent-loops/plugin.yaml
@@ -1,0 +1,19 @@
+name: agent-loops
+version: 2.1.0
+description: "Composable agent loop architectures — learning loops, 0-to-N inner agent orchestration, and red team coordination. Framework-agnostic."
+author: Richard Fremmerlid
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - agent_orchestrator
+  - swarm_run
+skills:
+  - agent-swarm
+  - dual-loop
+  - learning-loop
+  - orchestrator
+  - red-team-review
+  - triple-loop-learning

--- a/plugins/agent-scaffolders/plugin.yaml
+++ b/plugins/agent-scaffolders/plugin.yaml
@@ -1,0 +1,42 @@
+name: agent-scaffolders
+version: 2.0.0
+description: "Ecosystem generation primitives — scaffolds agent skills, plugins, CLI sub-agents, GitHub workflows, Azure Foundry agents, and more."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - scaffold
+  - scaffold_github_action
+  - scaffold_azure_agent
+  - scaffold_agentic_workflow
+  - audit
+  - inventory_plugin
+skills:
+  - analyze-plugin
+  - audit-plugin
+  - audit-plugin-l5
+  - create-agentic-workflow
+  - create-azure-agent
+  - create-command
+  - create-docker-skill
+  - create-github-action
+  - create-hook
+  - create-mcp-integration
+  - create-plugin
+  - create-skill
+  - create-stateful-skill
+  - create-sub-agent
+  - ecosystem-authoritative-sources
+  - ecosystem-standards
+  - eval-autoresearch-fit
+  - fix-plugin-paths
+  - l5-red-team-auditor
+  - manage-marketplace
+  - mine-plugins
+  - mine-skill
+  - path-reference-auditor
+  - self-audit
+  - synthesize-learnings

--- a/plugins/claude-cli/plugin.yaml
+++ b/plugins/claude-cli/plugin.yaml
@@ -1,0 +1,16 @@
+name: claude-cli
+version: 2.0.0
+description: "Claude CLI sub-agent system for persona-based analysis — pipes large contexts to Anthropic models for security audits, architecture reviews, and QA."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - run_agent
+  - optimize_context
+skills:
+  - claude-cli-agent
+  - claude-project-setup
+  - optimize-context

--- a/plugins/coding-conventions/plugin.yaml
+++ b/plugins/coding-conventions/plugin.yaml
@@ -1,0 +1,13 @@
+name: coding-conventions
+version: 2.0.0
+description: "Coding standards, documentation conventions, and header templates for Python, TypeScript/JavaScript, and C#/.NET."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - audit_scripts_conventions
+skills:
+  - coding-conventions-agent

--- a/plugins/context-bundler/plugin.yaml
+++ b/plugins/context-bundler/plugin.yaml
@@ -1,0 +1,16 @@
+name: context-bundler
+version: 2.1.0
+description: "Bundle source files and docs into single-file LLM context packages (Markdown or ZIP) for portable AI agent distribution."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - bundle
+  - bundle_zip
+  - manifest_manager
+skills:
+  - context-bundler
+  - red-team-bundler

--- a/plugins/copilot-cli/plugin.yaml
+++ b/plugins/copilot-cli/plugin.yaml
@@ -1,0 +1,13 @@
+name: copilot-cli
+version: 2.0.0
+description: "Copilot CLI sub-agent system for persona-based analysis — pipes large contexts to GitHub Copilot models for security audits, architecture reviews, and QA."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - run_agent
+skills:
+  - copilot-cli-agent

--- a/plugins/dependency-management/plugin.yaml
+++ b/plugins/dependency-management/plugin.yaml
@@ -1,0 +1,11 @@
+name: dependency-management
+version: 2.0.0
+description: "Python dependency management with pip-compile locked-file workflow and tiered hierarchy for Python backends."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+skills:
+  - dependency-management

--- a/plugins/exploration-cycle-plugin/plugin.yaml
+++ b/plugins/exploration-cycle-plugin/plugin.yaml
@@ -1,0 +1,29 @@
+name: exploration-cycle-plugin
+version: 0.1.0
+description: "Autonomous discovery, business requirements capture, and prototyping loop for spec-driven engineering."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - business_requirements_capture_execute
+  - exploration_handoff_execute
+  - exploration_optimizer_execute
+  - exploration_orchestrator_execute
+  - exploration_session_brief_execute
+  - prototype_builder_execute
+  - user_story_capture_execute
+skills:
+  - business-requirements-capture
+  - business-workflow-doc
+  - discovery-planning
+  - exploration-handoff
+  - exploration-optimizer
+  - exploration-session-brief
+  - exploration-workflow
+  - prototype-builder
+  - subagent-driven-prototyping
+  - user-story-capture
+  - visual-companion

--- a/plugins/gemini-cli/plugin.yaml
+++ b/plugins/gemini-cli/plugin.yaml
@@ -1,0 +1,14 @@
+name: gemini-cli
+version: 2.0.0
+description: "Gemini CLI sub-agent system for persona-based analysis — pipes large contexts to Google Gemini models for security audits, architecture reviews, and QA."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - run_agent
+skills:
+  - antigravity-project-setup
+  - gemini-cli-agent

--- a/plugins/huggingface-utils/plugin.yaml
+++ b/plugins/huggingface-utils/plugin.yaml
@@ -1,0 +1,15 @@
+name: huggingface-utils
+version: 2.0.0
+description: "HuggingFace integration utilities for Soul persistence — validates credentials, manages dataset structure, and provides upload primitives with exponential backoff."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - hf_init
+  - hf_upload
+skills:
+  - hf-init
+  - hf-upload

--- a/plugins/link-checker/plugin.yaml
+++ b/plugins/link-checker/plugin.yaml
@@ -1,0 +1,16 @@
+name: link-checker
+version: 2.0.0
+description: "QA agent for documentation link integrity — checks, fixes, and audits links across a repository using a deterministic Map-Fix-Verify workflow."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - audit_broken_links
+  - autofix_unique_links
+  - symlink_manager
+skills:
+  - link-checker-agent
+  - symlink-manager

--- a/plugins/memory-management/plugin.yaml
+++ b/plugins/memory-management/plugin.yaml
@@ -1,0 +1,11 @@
+name: memory-management
+version: 2.0.0
+description: "Tiered memory system for cognitive continuity across agent sessions — hot cache (boot-loaded) and deep storage (on-demand) with configurable promotion/demotion rules."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+skills:
+  - memory-management

--- a/plugins/mermaid-to-png/plugin.yaml
+++ b/plugins/mermaid-to-png/plugin.yaml
@@ -1,0 +1,14 @@
+name: mermaid-to-png
+version: 2.0.0
+description: "Convert Mermaid diagrams (.mmd) into high-resolution PNG images via headless Puppeteer."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - convert
+  - verify_png
+skills:
+  - convert-mermaid

--- a/plugins/obsidian-wiki-engine/plugin.yaml
+++ b/plugins/obsidian-wiki-engine/plugin.yaml
@@ -1,0 +1,29 @@
+name: obsidian-wiki-engine
+version: 3.1.0
+description: "Karpathy-style LLM wiki + RLM distillation + vector search. Dual-representation knowledge graph with vault ops, concept synthesis, wiki generation, semantic linting, and graph traversal."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - vault_ops
+  - wiki_builder
+  - distill_wiki
+  - query_wiki
+  - lint_wiki
+  - graph_ops
+  - canvas_gen
+  - bases_ops
+skills:
+  - obsidian-bases-manager
+  - obsidian-canvas-architect
+  - obsidian-graph-traversal
+  - obsidian-init
+  - obsidian-markdown-mastery
+  - obsidian-query-agent
+  - obsidian-rlm-distiller
+  - obsidian-vault-crud
+  - obsidian-wiki-builder
+  - obsidian-wiki-linter

--- a/plugins/plugin-manager/plugin.yaml
+++ b/plugins/plugin-manager/plugin.yaml
@@ -1,0 +1,18 @@
+name: plugin-manager
+version: 2.0.0
+description: "Orchestration hub for the plugin ecosystem — structural audits, agent environment sync, cross-repo replication, and Universal Bridge Installation for 30+ target environments."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - plugin_add
+  - plugin_installer
+  - plugin_remove
+  - sync_with_inventory
+skills:
+  - plugin-installer
+  - plugin-remover
+  - plugin-syncer

--- a/plugins/rlm-factory/plugin.yaml
+++ b/plugins/rlm-factory/plugin.yaml
@@ -1,0 +1,22 @@
+name: rlm-factory
+version: 2.0.0
+description: "Recursive Language Model factory — distills repository files into semantic summaries for instant context retrieval and vector search."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - distill_one
+  - query_cache
+  - audit_cache
+  - cleanup_cache
+  - inventory
+skills:
+  - rlm-audit
+  - rlm-cleanup-agent
+  - rlm-curator
+  - rlm-distill-agent
+  - rlm-init
+  - rlm-search

--- a/plugins/rsvp-speed-reader/plugin.yaml
+++ b/plugins/rsvp-speed-reader/plugin.yaml
@@ -1,0 +1,16 @@
+name: rsvp-speed-reader
+version: 1.0.0
+description: "Converts documents into word-by-word RSVP token streams with ORP alignment for speed reading. Supports .txt, .md, .pdf, and .docx."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - execute
+  - orp_engine
+  - parse_document
+skills:
+  - rsvp-comprehension-agent
+  - rsvp-reading

--- a/plugins/spec-kitty-plugin/plugin.yaml
+++ b/plugins/spec-kitty-plugin/plugin.yaml
@@ -1,0 +1,32 @@
+name: spec-kitty-plugin
+version: 2.0.0
+description: "Spec-Driven Development lifecycle + Universal Bridge sync engine — flagship workflow plugin for AI-assisted feature development."
+author: Richard Fremmerlid
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - sync_configuration
+  - verify_workflow_state
+skills:
+  - spec-kitty-accept
+  - spec-kitty-analyze
+  - spec-kitty-checklist
+  - spec-kitty-clarify
+  - spec-kitty-constitution
+  - spec-kitty-dashboard
+  - spec-kitty-implement
+  - spec-kitty-merge
+  - spec-kitty-plan
+  - spec-kitty-research
+  - spec-kitty-review
+  - spec-kitty-specify
+  - spec-kitty-status
+  - spec-kitty-sync-plugin
+  - spec-kitty-tasks
+  - spec-kitty-tasks-finalize
+  - spec-kitty-tasks-outline
+  - spec-kitty-tasks-packages
+  - spec-kitty-workflow

--- a/plugins/task-manager/plugin.yaml
+++ b/plugins/task-manager/plugin.yaml
@@ -1,0 +1,14 @@
+name: task-manager
+version: 2.0.0
+description: "Lightweight directory-backed kanban board with zero dependencies. V2 enforces Kanban Sovereignty constraints preventing manual task file edits."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - task_manager
+  - next_number
+skills:
+  - task-agent

--- a/plugins/vector-db/plugin.yaml
+++ b/plugins/vector-db/plugin.yaml
@@ -1,0 +1,22 @@
+name: vector-db
+version: 2.0.0
+description: "Local semantic search engine powered by ChromaDB with Super-RAG context injection via RLM summaries. Ingest, query, and maintain a persistent vector store."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - ingest
+  - query
+  - init
+  - audit_vector
+  - cleanup
+skills:
+  - vector-db-audit
+  - vector-db-cleanup
+  - vector-db-ingest
+  - vector-db-init
+  - vector-db-launch
+  - vector-db-search

--- a/plugins/voice-writer/plugin.yaml
+++ b/plugins/voice-writer/plugin.yaml
@@ -1,0 +1,11 @@
+name: voice-writer
+version: 0.1.0
+description: "Transform AI-generated or over-polished writing into authentic human voice. Supports voice profile calibration so the agent learns your specific style."
+author: Richard Fremmerlid
+kind: backend
+platforms:
+  - linux
+  - macos
+  - windows
+skills:
+  - humanize


### PR DESCRIPTION
Adds plugin.yaml manifests in hermes format (name, version, description, author, kind, platforms, provides_tools, skills) to each plugin so they are fully discoverable by the hermes-agent plugin system.