### PR TITLE
feat(agent-scaffolders): update create-plugin skill to generate plugi…

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,33 @@
+name: agent-plugins-skills
+version: 2.0.0
+description: "Plugin ecosystem for AI agents — skills, scaffolders, loops, memory, vector search, spec-driven dev, and more. Install individual plugins or the full suite."
+author: Richard Fremmerlid
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+skills_dirs:
+  - plugins/adr-manager/skills
+  - plugins/agent-agentic-os/skills
+  - plugins/agent-loops/skills
+  - plugins/agent-scaffolders/skills
+  - plugins/claude-cli/skills
+  - plugins/coding-conventions/skills
+  - plugins/context-bundler/skills
+  - plugins/copilot-cli/skills
+  - plugins/dependency-management/skills
+  - plugins/exploration-cycle-plugin/skills
+  - plugins/gemini-cli/skills
+  - plugins/huggingface-utils/skills
+  - plugins/link-checker/skills
+  - plugins/memory-management/skills
+  - plugins/mermaid-to-png/skills
+  - plugins/obsidian-wiki-engine/skills
+  - plugins/plugin-manager/skills
+  - plugins/rlm-factory/skills
+  - plugins/rsvp-speed-reader/skills
+  - plugins/spec-kitty-plugin/skills
+  - plugins/task-manager/skills
+  - plugins/vector-db/skills
+  - plugins/voice-writer/skills

--- a/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
@@ -27,7 +27,28 @@ Follow the `create-plugin` skill workflow to scaffold a new Claude Code plugin.
    - Verify each hook appears in the `hooks` list.
    - Add any missing entries immediately — do NOT wait for the user to ask.
    - Report: *"All components are registered in `plugin.json`. ✅"* or list additions made.
-4. Report the created plugin directory and verification checklist results
+4. **plugin.yaml (Hermes compatibility — always generate):** After `plugin.json` is finalized, scaffold a `plugin.yaml` at the plugin root for hermes-agent compatibility. Format:
+   ```yaml
+   name: <plugin-name>
+   version: <version>
+   description: "<description>"
+   author: <author>
+   kind: backend  # or standalone (no Python scripts)
+   platforms:
+     - linux
+     - macos
+     - windows
+   provides_tools:          # list script basenames (no .py) that expose callable tools
+     - script_name
+   skills:                  # list skill directory names under skills/
+     - skill-name
+   ```
+   - `kind: standalone` — plugin has no Python scripts that hermes calls directly
+   - `kind: backend` — plugin has scripts in `scripts/` that hermes invokes as tools
+   - Only include `provides_tools` if `scripts/` contains callable tool scripts
+   - Skills list must match actual directory names under `skills/`
+   - Report: *"`plugin.yaml` created for hermes compatibility. ✅"*
+5. Report the created plugin directory and verification checklist results
 
 ## Output
 


### PR DESCRIPTION
…n.yaml

Adds mandatory Step 4 to create-plugin workflow: scaffold a hermes-native plugin.yaml alongside .claude-plugin/plugin.json so plugins work in both Claude Code and hermes-agent without manual post-processing.