### PR TITLE
fix(create-plugin): use bare skill name in register_skill() example

### DIFF
--- a/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-plugin/SKILL.md
@@ -58,7 +58,7 @@ Follow the `create-plugin` skill workflow to scaffold a new Claude Code plugin.
    def register(ctx) -> None:
        # Register skills
        ctx.register_skill(
-           name="<plugin-name>:<skill-name>",
+           name="<skill-name>",   # bare name only — hermes auto-prefixes plugin name as namespace
            path=_HERE / "skills" / "<skill-name>",
        )
        # Register tools (if scripts expose callable tools)


### PR DESCRIPTION
Hermes auto-prefixes the plugin name as namespace. Passing 'plugin:skill' causes a validation error — skill name must be bare.