### PR TITLE
fix(plugin-manager): remove circular directory symlink causing Recurs…

### DIFF
--- a/plugins/plugin-manager/skills/plugin-installer/assets/templates/templates
+++ b/plugins/plugin-manager/skills/plugin-installer/assets/templates/templates
@@ -1,1 +1,0 @@
-../../assets/templates


### PR DESCRIPTION
…ionError

The templates/templates directory symlink pointed back to its own parent (assets/templates), causing infinite recursion in _copy_resolving_pointers during uvx install. Removed per ADR-003 (no directory symlinks allowed).