### PR TITLE
fix(exploration-cycle-plugin): correct invalid SessionStop hook to Se…

### DIFF
--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -11,7 +11,7 @@
         ]
       }
     ],
-    "SessionStop": [
+    "SessionEnd": [
       {
         "matcher": "",
         "hooks": [


### PR DESCRIPTION
This pull request updates the plugin hook configuration to use a more accurate event name. The `SessionStop` event has been replaced with `SessionEnd` in the `hooks.json` file.

- Event naming update:
  * Replaced the `SessionStop` event with `SessionEnd` in `plugins/exploration-cycle-plugin/hooks/hooks.json` to better reflect the intended session lifecycle event.…ssionEnd