### PR TITLE
chore: update plugin-sources.json and skills-lock.json after local re…

### DIFF
--- a/plugin-sources.json
+++ b/plugin-sources.json
@@ -28,7 +28,6 @@
         "context-bundler",
         "copilot-cli",
         "dependency-management",
-        "exploration-cycle-plugin",
         "gemini-cli",
         "link-checker"
       ]
@@ -37,6 +36,12 @@
       "source": "obra/superpowers",
       "plugins": [
         "superpowers"
+      ]
+    },
+    {
+      "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
+      "plugins": [
+        "exploration-cycle-plugin"
       ]
     }
   ]

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -123,14 +123,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "business-workflow-doc": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -343,7 +343,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "dispatching-parallel-agents": {
       "source": "https://github.com/obra/superpowers",
@@ -474,14 +474,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "exploration-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
@@ -495,14 +495,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "exploration-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "finishing-a-development-branch": {
       "source": "https://github.com/obra/superpowers",
@@ -988,7 +988,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "receiving-code-review": {
       "source": "https://github.com/obra/superpowers",
@@ -1340,7 +1340,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1424,7 +1424,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "using-git-worktrees": {
       "source": "https://github.com/obra/superpowers",
@@ -1508,21 +1508,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-browser-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-domain-extractor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1536,42 +1536,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-slice-migrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-spec-packager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-to-speckit-superpowers": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T19:13:31.238310Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "vibe-togaf-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "visual-companion": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-22T19:14:46.273373Z"
+      "updatedAt": "2026-05-31T04:22:07.071090Z"
     },
     "writing-plans": {
       "source": "https://github.com/obra/superpowers",


### PR DESCRIPTION
This pull request updates the plugin configuration to change how the `exploration-cycle-plugin` is sourced and updates the timestamps for several skills in the lock file. The main change is that `exploration-cycle-plugin` is now loaded from a local directory instead of the default plugin list.

Plugin source management:

* The `exploration-cycle-plugin` was removed from the main plugin list and is now explicitly sourced from a local directory (`/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins`) in `plugin-sources.json`. This allows for local development and testing of the plugin. [[1]](diffhunk://#diff-8cbf44b5f3bb8a19bde67d57cb8975503881d27437af0d864ea7f2f292f72cb3L31) [[2]](diffhunk://#diff-8cbf44b5f3bb8a19bde67d57cb8975503881d27437af0d864ea7f2f292f72cb3R40-R45)

Skill metadata updates:

* Updated the `updatedAt` timestamps for multiple skills in `skills-lock.json` to reflect the latest installation or update time. No functional changes to the skills themselves. [[1]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL126-R133) [[2]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL346-R346) [[3]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL477-R484) [[4]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL498-R505) [[5]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL991-R991) [[6]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL1343-R1343) [[7]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL1427-R1427) [[8]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL1511-R1525) [[9]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL1539-R1574)…install