### PR TITLE
fix(exploration-cycle-plugin): use python3 in hook commands

### DIFF
--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }


### PR DESCRIPTION
macOS does not have a 'python' binary — hooks were failing with 'command not found'. Both SessionStart and SessionEnd updated.