### PR TITLE
fix(marketplace): remove non-existent plugins and fix invalid hooks f…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,14 +70,6 @@
       "tags": ["orchestration", "sync", "installer", "package-manager", "deployment"]
     },
     {
-      "name": "agent-plugin-analyzer",
-      "description": "Systematically analyze agent plugins and skills to extract design patterns, architectural decisions, and reusable techniques. Translates analysis into concrete improvement recommendations.",
-      "source": "./plugins/agent-plugin-analyzer",
-      "strict": true,
-      "category": "analysis",
-      "tags": ["plugin-analyzer", "pattern-extraction", "security-audit", "maturity-model"]
-    },
-    {
       "name": "coding-conventions",
       "description": "Coding standards, documentation conventions, and header templates for Python, TypeScript/JavaScript, and C#/.NET.",
       "source": "./plugins/coding-conventions",
@@ -100,14 +92,6 @@
       "strict": true,
       "category": "analysis",
       "tags": ["links", "documentation", "validation", "auto-repair", "markdown"]
-    },
-    {
-      "name": "agent-skill-open-specifications",
-      "description": "Authoritative reference documentation and execution skills for the Agent Skills and Claude Plugin ecosystem standards.",
-      "source": "./plugins/agent-skill-open-specifications",
-      "strict": true,
-      "category": "analysis",
-      "tags": ["ecosystem-specs", "plugin-standards", "skill-standards", "authoritative-reference"]
     },
     {
       "name": "context-bundler",
@@ -175,9 +159,9 @@
       "tags": ["mermaid", "diagrams", "png", "convert", "visualization", "puppeteer"]
     },
     {
-      "name": "obsidian-integration",
+      "name": "obsidian-wiki-engine",
       "description": "Obsidian Agent Integration Suite — vault operations, markdown parsing, canvas creation, graph traversal, and bases management for AI-assisted Obsidian workflows.",
-      "source": "./plugins/obsidian-integration",
+      "source": "./plugins/obsidian-wiki-engine",
       "strict": true,
       "category": "integrations",
       "tags": ["obsidian", "vault", "knowledge-graph", "markdown", "canvas", "pkm"]

--- a/plugin-sources.json
+++ b/plugin-sources.json
@@ -4,7 +4,18 @@
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills",
       "plugins": [
         "adr-manager",
+        "agent-agentic-os",
+        "agent-loops",
+        "agent-scaffolders",
+        "claude-cli",
+        "coding-conventions",
+        "context-bundler",
+        "copilot-cli",
+        "dependency-management",
+        "exploration-cycle-plugin",
+        "gemini-cli",
         "huggingface-utils",
+        "link-checker",
         "memory-management",
         "mermaid-to-png",
         "obsidian-wiki-engine",
@@ -18,30 +29,9 @@
       ]
     },
     {
-      "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
-      "plugins": [
-        "agent-agentic-os",
-        "agent-loops",
-        "agent-scaffolders",
-        "claude-cli",
-        "coding-conventions",
-        "context-bundler",
-        "copilot-cli",
-        "dependency-management",
-        "gemini-cli",
-        "link-checker"
-      ]
-    },
-    {
       "source": "obra/superpowers",
       "plugins": [
         "superpowers"
-      ]
-    },
-    {
-      "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
-      "plugins": [
-        "exploration-cycle-plugin"
       ]
     }
   ]

--- a/plugins/agent-agentic-os/.claude-plugin/plugin.json
+++ b/plugins/agent-agentic-os/.claude-plugin/plugin.json
@@ -47,6 +47,5 @@
         "os-init",
         "os-loop",
         "os-memory"
-    ],
-    "hooks": true
+    ]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-05-22T19:14:43.938702Z"
+      "updatedAt": "2026-05-31T04:47:00.706980Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -67,7 +67,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -88,28 +88,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "antigravity-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:45.204613Z",
-      "updatedAt": "2026-05-22T19:14:46.324795Z"
+      "updatedAt": "2026-05-31T04:47:02.310249Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "brainstorming": {
       "source": "https://github.com/obra/superpowers",
@@ -123,21 +123,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "business-workflow-doc": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:37.067705Z",
-      "updatedAt": "2026-05-22T19:14:45.889498Z"
+      "updatedAt": "2026-05-31T04:47:01.901879Z"
     },
     "claude-cli-claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -151,14 +151,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:44.824639Z",
-      "updatedAt": "2026-05-22T19:14:45.889498Z"
+      "updatedAt": "2026-05-31T04:47:01.901879Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:37.700984Z",
-      "updatedAt": "2026-05-22T19:14:45.938694Z"
+      "updatedAt": "2026-05-31T04:47:01.961460Z"
     },
     "coding-conventions-coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -172,7 +172,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -191,7 +191,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-05-22T19:14:45.991374Z"
+      "updatedAt": "2026-05-31T04:47:02.019761Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -212,21 +212,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-05-22T19:14:46.572873Z"
+      "updatedAt": "2026-05-31T04:47:02.555142Z"
     },
     "convert-plugin-to-apm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:38.954419Z",
-      "updatedAt": "2026-05-22T19:14:46.056080Z"
+      "updatedAt": "2026-05-31T04:47:02.076865Z"
     },
     "copilot-cli-copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -240,49 +240,49 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -294,35 +294,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "deferred": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -336,14 +336,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-05-22T19:14:46.101645Z"
+      "updatedAt": "2026-05-31T04:47:02.127778Z"
     },
     "discovery-planning": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "dispatching-parallel-agents": {
       "source": "https://github.com/obra/superpowers",
@@ -357,28 +357,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "eval-autoresearch-fit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:54:04.213659Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -474,14 +474,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "exploration-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
@@ -495,14 +495,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "exploration-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "finishing-a-development-branch": {
       "source": "https://github.com/obra/superpowers",
@@ -516,7 +516,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T18:32:57.701906Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -528,7 +528,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.069557Z",
-      "updatedAt": "2026-05-22T19:14:46.324795Z"
+      "updatedAt": "2026-05-31T04:47:02.310249Z"
     },
     "gemini-cli-gemini-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -542,49 +542,49 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-05-22T19:14:46.379781Z"
+      "updatedAt": "2026-05-31T04:47:02.363097Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-05-22T19:14:46.379781Z"
+      "updatedAt": "2026-05-31T04:47:02.363097Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-05-22T19:14:47.442981Z"
+      "updatedAt": "2026-05-31T04:47:03.301673Z"
     },
     "install-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:43.095665Z",
-      "updatedAt": "2026-05-22T19:14:46.455619Z"
+      "updatedAt": "2026-05-31T04:47:02.439823Z"
     },
     "link-checker-link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -605,7 +605,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -619,91 +619,91 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:43.893614Z",
-      "updatedAt": "2026-05-22T19:14:46.510748Z"
+      "updatedAt": "2026-05-31T04:47:02.491086Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-query-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-rlm-distiller": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-wiki-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "obsidian-wiki-linter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-05-22T19:14:46.667452Z"
+      "updatedAt": "2026-05-31T04:47:02.657144Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -717,14 +717,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T14:43:50.703180Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "optimize-context": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-11T15:20:19.257058Z",
-      "updatedAt": "2026-05-22T19:14:45.889498Z"
+      "updatedAt": "2026-05-31T04:47:01.901879Z"
     },
     "oracle-legacy-system-analysis-business-rules": {
       "source": "oracle-legacy-system-analysis",
@@ -829,35 +829,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "os-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-environment-probe": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-26T18:04:54.227742Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-eval-lab": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -871,70 +871,70 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:55:32.819746Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-evolution-planner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-evolution-verifier": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-experiment-log": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -955,28 +955,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "plugin-installer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-05-22T19:14:46.728109Z"
+      "updatedAt": "2026-05-31T04:47:02.713899Z"
     },
     "plugin-remover": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T14:53:48.497968Z",
-      "updatedAt": "2026-05-22T19:14:46.728109Z"
+      "updatedAt": "2026-05-31T04:47:02.713899Z"
     },
     "plugin-syncer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T15:51:44.964142Z",
-      "updatedAt": "2026-05-22T19:14:46.728109Z"
+      "updatedAt": "2026-05-31T04:47:02.713899Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -988,7 +988,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "receiving-code-review": {
       "source": "https://github.com/obra/superpowers",
@@ -1002,14 +1002,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-05-22T19:14:45.991374Z"
+      "updatedAt": "2026-05-31T04:47:02.019761Z"
     },
     "red-team-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1030,28 +1030,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.409753Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1093,28 +1093,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-05-22T19:14:46.916699Z"
+      "updatedAt": "2026-05-31T04:47:02.926621Z"
     },
     "rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-05-22T19:14:47.089978Z"
+      "updatedAt": "2026-05-31T04:47:02.980650Z"
     },
     "rsvp-reading": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:49.120405Z",
-      "updatedAt": "2026-05-22T19:14:47.089978Z"
+      "updatedAt": "2026-05-31T04:47:02.980650Z"
     },
     "rsvp-speed-reader-rsvp-comprehension-agent": {
       "source": "https://github.com/richfrem/Project_Sanctuary",
@@ -1153,14 +1153,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "self-evolution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:48.041518Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1181,7 +1181,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-agent": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -1193,70 +1193,70 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-checklist": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-clarify": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-constitution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-dashboard": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-implement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-merge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-plan": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-research": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-spec-kitty-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1277,56 +1277,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-status": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-sync-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-tasks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-tasks-finalize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-tasks-outline": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-tasks-packages": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "spec-kitty-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:51.892003Z",
-      "updatedAt": "2026-05-22T19:14:47.257915Z"
+      "updatedAt": "2026-05-31T04:47:03.102707Z"
     },
     "subagent-driven-development": {
       "source": "https://github.com/obra/superpowers",
@@ -1340,21 +1340,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-31T19:06:22.971138Z",
-      "updatedAt": "2026-05-22T19:14:46.455619Z"
+      "updatedAt": "2026-05-31T04:47:02.439823Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "systematic-debugging": {
       "source": "https://github.com/obra/superpowers",
@@ -1368,7 +1368,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-05-22T19:14:47.306593Z"
+      "updatedAt": "2026-05-31T04:47:03.161829Z"
     },
     "task-manager-task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1389,7 +1389,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-05-22T19:14:45.125468Z"
+      "updatedAt": "2026-05-31T04:47:00.874265Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1410,21 +1410,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T20:54:39.722191Z",
-      "updatedAt": "2026-05-22T19:14:45.206560Z"
+      "updatedAt": "2026-05-31T04:47:00.966460Z"
     },
     "update-ecosystem-index": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-05-22T19:14:45.821228Z"
+      "updatedAt": "2026-05-31T04:47:01.843374Z"
     },
     "user-story-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "using-git-worktrees": {
       "source": "https://github.com/obra/superpowers",
@@ -1445,42 +1445,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.726867Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:54.318238Z",
-      "updatedAt": "2026-05-22T19:14:47.396527Z"
+      "updatedAt": "2026-05-31T04:47:03.256029Z"
     },
     "vector-db-vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1508,21 +1508,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-browser-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-domain-extractor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1536,42 +1536,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-slice-migrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-spec-packager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-to-speckit-superpowers": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T19:13:31.238310Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "vibe-togaf-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "visual-companion": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-05-31T04:22:07.071090Z"
+      "updatedAt": "2026-05-31T04:47:02.254812Z"
     },
     "writing-plans": {
       "source": "https://github.com/obra/superpowers",


### PR DESCRIPTION
…ield

- Remove agent-plugin-analyzer and agent-skill-open-specifications from marketplace.json (directories never created, caused install failures)
- Rename obsidian-integration → obsidian-wiki-engine to match actual dir name
- Remove "hooks": true from agent-agentic-os plugin.json (invalid field; hooks/ directory is auto-discovered, no declaration needed)
- Update plugin-sources.json to remove stale Windows path and add current plugins
- Refresh skills-lock.json timestamps after local reinstall