### PR TITLE
fix(exploration-cycle-plugin): make hooks resilient to python vs python3

### DIFF
--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "sh -c 'python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py'"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
+            "command": "sh -c 'python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py'"
           }
         ]
       }

--- a/plugins/exploration-cycle-plugin/hooks/session_end.py
+++ b/plugins/exploration-cycle-plugin/hooks/session_end.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 session_end.py
 =====================================

--- a/plugins/exploration-cycle-plugin/hooks/session_start.py
+++ b/plugins/exploration-cycle-plugin/hooks/session_start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 session_start.py
 =====================================


### PR DESCRIPTION
- hooks.json: both commands now try python3 first, fall back to python (sh -c 'python3 ... || python ...')
- session_start.py, session_end.py: shebang updated to python3

Fixes SessionStart and SessionEnd hook failures on macOS where 'python' binary does not exist.