### PR TITLE
fix: replace bare 'python' with 'python3' in all plugin hooks

### DIFF
--- a/plugins/agent-agentic-os/hooks/hooks.json
+++ b/plugins/agent-agentic-os/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
           }
         ]
       }

--- a/plugins/agent-loops/hooks/hooks.json
+++ b/plugins/agent-loops/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
             "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete."
           }
         ]

--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py'"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py'"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }


### PR DESCRIPTION
exploration-cycle-plugin: SessionStart + SessionEnd
agent-loops: Stop (closure_guard.py)
agent-agentic-os: SessionStart, PostToolUse, Stop

macOS does not ship a 'python' binary. Also reverts the broken 'sh -c' wrapper that prevented CLAUDE_PLUGIN_ROOT expansion.