### PR TITLE
fix(agent-agentic-os): sync plugin.json with actual skills and agents…

### DIFF
--- a/plugins/agent-agentic-os/.claude-plugin/plugin.json
+++ b/plugins/agent-agentic-os/.claude-plugin/plugin.json
@@ -28,19 +28,28 @@
     ],
     "skills": [
         "optimize-agent-instructions",
+        "os-architect",
         "os-clean-locks",
+        "os-environment-probe",
         "os-eval-backport",
         "os-eval-lab-setup",
         "os-eval-runner",
+        "os-evolution-planner",
+        "os-evolution-verifier",
+        "os-experiment-log",
         "os-guide",
         "os-improvement-loop",
         "os-improvement-report",
         "os-init",
         "os-memory-manager",
+        "self-evolution",
         "todo-check"
     ],
     "agents": [
         "agentic-os-setup",
+        "improvement-intake-agent",
+        "os-architect-agent",
+        "os-architect-tester-agent",
         "os-health-check"
     ],
     "commands": [


### PR DESCRIPTION
… directories

plugin.json was missing 6 skills and 3 agents that exist in the plugin: Skills added: os-architect, os-environment-probe, os-evolution-planner,
              os-evolution-verifier, os-experiment-log, self-evolution
Agents added: improvement-intake-agent, os-architect-agent, os-architect-tester-agent

Mismatch caused Claude Code marketplace installer to reject the plugin.