### PR TITLE
feat(audit-plugin): add marketplace source path audit check

### DIFF
--- a/plugins/agent-scaffolders/scripts/audit_marketplace_sources.py
+++ b/plugins/agent-scaffolders/scripts/audit_marketplace_sources.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+audit_marketplace_sources.py
+============================
+
+Validates that every plugin entry in .claude-plugin/marketplace.json points to a
+directory that actually exists. Missing source paths cause silent install failures
+in the Claude Code /plugin UI with no actionable error message.
+
+Usage:
+    python audit_marketplace_sources.py [repo_root]
+    python audit_marketplace_sources.py .
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def audit(repo_root: Path) -> int:
+    marketplace = repo_root / ".claude-plugin" / "marketplace.json"
+    if not marketplace.exists():
+        print(f"No marketplace.json found at {marketplace}")
+        return 0
+
+    try:
+        with marketplace.open() as f:
+            m = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: marketplace.json is invalid JSON: {e}")
+        return 1
+
+    plugins = m.get("plugins", [])
+    failures = []
+
+    for p in plugins:
+        name = p.get("name", "<unnamed>")
+        source = p.get("source")
+        if not isinstance(source, str) or not source.startswith("./"):
+            continue  # non-relative sources (github, npm, url) can't be checked locally
+        path = repo_root / source[2:]  # strip leading ./
+        if not path.is_dir():
+            failures.append((name, str(source), str(path)))
+
+    if failures:
+        print(f"Broken marketplace source paths ({len(failures)} of {len(plugins)}):\n")
+        for name, source, path in failures:
+            print(f"  MISS  {name:<40s}  {source}")
+            print(f"        resolved to: {path}")
+        print(
+            "\nFix: update 'source' in marketplace.json to match the real directory name, "
+            "or remove the entry."
+        )
+        return 1
+
+    print(f"✓ All {len(plugins)} marketplace entries have valid source paths.")
+    return 0
+
+
+def main() -> None:
+    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    if not repo_root.is_dir():
+        print(f"ERROR: Not a directory: {repo_root}")
+        sys.exit(1)
+    sys.exit(audit(repo_root.resolve()))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/agent-scaffolders/skills/audit-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/audit-plugin/SKILL.md
@@ -94,7 +94,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/fix_plugin_load_errors.py <plugin_root>
 
 | Issue | Symptom in /doctor | Root cause |
 |---|---|---|
-| `plugin.json` has `skills`/`agents`/`hooks`/`commands` arrays | `Invalid input` | Validator rejects these — auto-discovery handles them |
+| `plugin.json` has `skills`/`agents`/`hooks`/`commands` field (any value — array, boolean `true`, object) | `Invalid input` | Validator rejects these entirely — auto-discovery handles them; `"hooks": true` is a common mistake |
 | `hooks.json` is `{}` (empty object) | `expected record, received undefined` | Must be `{"hooks": {}}` |
 | `hooks.json` is `[]` (array) | `expected object received array` | Must be an object |
 | `hooks.json` flat format `{"EventName":{...}}` | `expected record, received undefined` | Must be nested under `"hooks"` key |
@@ -258,6 +258,27 @@ grep -rn "/Users/\|/home/" --include="*.json" --include="*.sh" .
 ```
 "Review my skill at skills/skill-name/SKILL.md"
 ```
+
+---
+
+## Step 4b: Marketplace Source Path Audit
+
+If the repo contains a `.claude-plugin/marketplace.json`, run this check to ensure
+every plugin entry points to a directory that actually exists. Missing directories
+silently fail during `/plugin` install with no helpful error message.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/audit_marketplace_sources.py <repo_root>
+# or from the repo root:
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/audit_marketplace_sources.py .
+```
+
+**Common causes of missing paths:**
+- Plugin directory renamed but `marketplace.json` not updated (e.g. `obsidian-integration` → `obsidian-wiki-engine`)
+- Plugin entry added to marketplace before the plugin directory was created
+- Plugin directory deleted but marketplace entry not removed
+
+**Fix:** Either update the `source` path to match the real directory name, or remove the entry.
 
 ---
 

--- a/plugins/agent-scaffolders/skills/audit-plugin/scripts/audit_marketplace_sources.py
+++ b/plugins/agent-scaffolders/skills/audit-plugin/scripts/audit_marketplace_sources.py
@@ -1,0 +1,1 @@
+../../../scripts/audit_marketplace_sources.py


### PR DESCRIPTION
- Add audit_marketplace_sources.py script that validates all .claude-plugin/marketplace.json source paths resolve to real directories; exits 1 with clear MISS output if any are broken
- Add symlink plugins/agent-scaffolders/skills/audit-plugin/scripts/ → shared scripts/
- Add Step 4b to audit-plugin SKILL.md documenting the new check
- Fix Step 2b table: clarify "hooks": true (boolean) is also a banned field, not just arrays

Caught the three silent marketplace failures that caused /plugin installs to fail: agent-plugin-analyzer, agent-skill-open-specifications, obsidian-integration.