### PR TITLE
Fix/agent agentic os plugin json

### DIFF
--- a/plugins/agent-agentic-os/.claude-plugin/plugin.json
+++ b/plugins/agent-agentic-os/.claude-plugin/plugin.json
@@ -25,36 +25,5 @@
         "self-healing",
         "multi-agent-coordination",
         "hooks"
-    ],
-    "skills": [
-        "optimize-agent-instructions",
-        "os-architect",
-        "os-clean-locks",
-        "os-environment-probe",
-        "os-eval-backport",
-        "os-eval-lab-setup",
-        "os-eval-runner",
-        "os-evolution-planner",
-        "os-evolution-verifier",
-        "os-experiment-log",
-        "os-guide",
-        "os-improvement-loop",
-        "os-improvement-report",
-        "os-init",
-        "os-memory-manager",
-        "self-evolution",
-        "todo-check"
-    ],
-    "agents": [
-        "agentic-os-setup",
-        "improvement-intake-agent",
-        "os-architect-agent",
-        "os-architect-tester-agent",
-        "os-health-check"
-    ],
-    "commands": [
-        "os-init",
-        "os-loop",
-        "os-memory"
     ]
 }

--- a/plugins/agent-agentic-os/hooks/scripts/post_run_metrics.py
+++ b/plugins/agent-agentic-os/hooks/scripts/post_run_metrics.py
@@ -1,16 +1,1 @@
-#!/usr/bin/env python
-# Thin wrapper — delegates to the canonical implementation in scripts/
-import sys
-import os
-from pathlib import Path
-
-# Resolve CLAUDE_PLUGIN_ROOT or fall back to two levels up from this file
-plugin_root = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).parent.parent.parent))
-target = plugin_root / "scripts" / "post_run_metrics.py"
-
-if not target.exists():
-    print(f"ERROR: post_run_metrics.py not found at {target}", file=sys.stderr)
-    sys.exit(1)
-
-# Re-exec the real script so it runs in its own context
-os.execv(sys.executable, [sys.executable, str(target)] + sys.argv[1:])
+../../scripts/post_run_metrics.py

--- a/plugins/agent-agentic-os/scripts/post_run_metrics.py
+++ b/plugins/agent-agentic-os/scripts/post_run_metrics.py
@@ -72,7 +72,7 @@ def emit_event(project_root: Path, event_data: dict) -> None:
             summary_payload = summary_payload[:2048]
 
         cmd = [
-            "python, str(kernel_path), "emit_event",
+            "python3", str(kernel_path), "emit_event",
             "--agent", event_data["agent"],
             "--type", event_type,
             "--action", event_data["action"],
@@ -198,7 +198,7 @@ def main() -> None:
     if kernel_path.exists():
         try:
             subprocess.run([
-                "python, str(kernel_path), "emit_event",
+                "python3", str(kernel_path), "emit_event",
                 "--agent", "post_run_hook",
                 "--type", "metric",
                 "--action", "north_star_check_pending",


### PR DESCRIPTION
This pull request primarily refactors how the `post_run_metrics.py` script is referenced and executed, and cleans up the plugin configuration. The changes simplify script invocation, improve Python command correctness, and remove unused configuration entries.

**Plugin configuration cleanup:**
- Removed the `skills`, `agents`, and `commands` arrays from `plugin.json`, streamlining the plugin manifest and possibly reflecting a shift to auto-discovery or external configuration.

**Script invocation and path handling:**
- Replaced the wrapper script `hooks/scripts/post_run_metrics.py` with a direct relative symlink to `../../scripts/post_run_metrics.py`, simplifying maintenance and reducing indirection. [[1]](diffhunk://#diff-ce8897a1175185bb11841828251535d1e791dad08a14010b07aa9dfb5007e768L1-L16) [[2]](diffhunk://#diff-ce8897a1175185bb11841828251535d1e791dad08a14010b07aa9dfb5007e768R1)

**Python command correctness:**
- Fixed the invocation of Python in `scripts/post_run_metrics.py` from an invalid string (`"python, str(kernel_path), ...`) to a correct list format using `"python3"`, ensuring the kernel script is executed properly. [[1]](diffhunk://#diff-b35795f5255714135ca94662b076f78ed3138ae5e21aea14c9de639b329360f2L75-R75) [[2]](diffhunk://#diff-b35795f5255714135ca94662b076f78ed3138ae5e21aea14c9de639b329360f2L201-R201)