### PR TITLE
ci: fix ecosystem indexer push block by running on pull_request

### DIFF
--- a/.github/workflows/update-ecosystem.yml
+++ b/.github/workflows/update-ecosystem.yml
@@ -1,7 +1,7 @@
 name: Update Ecosystem Index
 
 on:
-  push:
+  pull_request:
     branches:
       - main
     paths:
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 137 Skills · 56 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 12 Plugins · 141 Skills · 43 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026)
@@ -185,7 +185,7 @@ Autonomous discovery loop: idea framing → business requirements → user stori
 
 ### Group 4: Code Quality & Safety
 
-#### agent-scaffolders — Boilerplate & Audit (31 skills)
+#### agent-scaffolders — Boilerplate & Audit (30 skills)
 
 Interactive creators for exact file hierarchies + structured audit framework for plugin architectural maturity.
 


### PR DESCRIPTION
This PR updates the Update Ecosystem Index workflow to trigger on pull requests and commit to the source branch, resolving push violations on main.