### PR TITLE
Fix/update ecosystem workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 12 Plugins · 141 Skills · 43 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 141 Skills · 43 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026)

--- a/plugins/agent-agentic-os/hooks/hooks.json
+++ b/plugins/agent-agentic-os/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
           }
         ]
       }

--- a/plugins/agent-loops/hooks/hooks.json
+++ b/plugins/agent-loops/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
             "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete."
           }
         ]

--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }


### PR DESCRIPTION
This pull request contains minor updates to the ecosystem statistics and standardizes the Python command used in various plugin hook configurations. The most important changes are:

**Ecosystem statistics update:**
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the plugin count in the ecosystem stats from 12 to 11.

**Hook command standardization:**
* `plugins/agent-agentic-os/hooks/hooks.json`, `plugins/agent-loops/hooks/hooks.json`, `plugins/exploration-cycle-plugin/hooks/hooks.json`: Changed the Python command from `python3` to `python` for all hook scripts to ensure consistency and compatibility across different environments. [[1]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L9-R9) [[2]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L20-R20) [[3]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L31-R31) [[4]](diffhunk://#diff-90a7be1b5e50ace40e36ad2a9ba49b59eeacdf8ac5684665a52253686167c49aL9-R9) [[5]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL9-R9) [[6]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL20-R20)