### PR TITLE
feat(plugin-installer): only warn about manual .mcp.json merge if ser…

### DIFF
--- a/plugin-sources.json
+++ b/plugin-sources.json
@@ -9,23 +9,23 @@
     {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills",
       "plugins": [
+        "rlm-factory"
+      ]
+    },
+    {
+      "source": "richfrem/agent-plugins-skills",
+      "plugins": [
         "agent-agentic-os",
         "agent-loops",
         "agent-memory",
         "agent-scaffolders",
         "cli-agents",
         "dependency-management",
+        "dev-utils",
         "exploration-cycle-plugin",
         "obsidian-wiki-engine",
         "plugin-manager",
-        "rlm-factory",
         "spec-kitty"
-      ]
-    },
-    {
-      "source": "richfrem/agent-plugins-skills",
-      "plugins": [
-        "dev-utils"
       ]
     }
   ]

--- a/plugins/plugin-manager/scripts/plugin_installer.py
+++ b/plugins/plugin-manager/scripts/plugin_installer.py
@@ -568,8 +568,13 @@ def provision_central_and_symlink(plugin_path: Path, metadata: dict, targets: li
     # MCP merge (future -- log intent for now)
     mcp_file = plugin_path / ".mcp.json"
     if mcp_file.exists():
-        print(f"  ⚠ .mcp.json found but merge not yet implemented - "
-              f"manually merge {mcp_file} into ./.mcp.json")
+        try:
+            mcp_data = json.loads(mcp_file.read_text(encoding="utf-8"))
+            if mcp_data.get("mcpServers"):
+                print(f"  ⚠ .mcp.json found but merge not yet implemented - "
+                      f"manually merge {mcp_file} into ./.mcp.json")
+        except Exception:
+            pass
               
     return installed_skills
 


### PR DESCRIPTION
This pull request updates plugin source configuration and improves error handling in the plugin installer script. The main changes are the reorganization of plugin listings in `plugin-sources.json` and enhanced robustness when reading `.mcp.json` files.

**Plugin source configuration:**
* Reorganized the `plugin-sources.json` file to move the `rlm-factory` plugin under the local path source and group `dev-utils` with other plugins under the `richfrem/agent-plugins-skills` source, removing a redundant entry.

**Installer script robustness:**
* Updated `plugin_installer.py` to wrap `.mcp.json` file reading in a try-except block, preventing errors if the file is malformed or unreadable.…vers are defined