### PR TITLE
Feature/hf download skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 141 Skills · 43 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 142 Skills · 43 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026)

--- a/plugins/agent-agentic-os/hooks/hooks.json
+++ b/plugins/agent-agentic-os/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
           }
         ]
       }

--- a/plugins/agent-loops/hooks/hooks.json
+++ b/plugins/agent-loops/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
             "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete."
           }
         ]

--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }


### PR DESCRIPTION
This pull request improves cross-platform compatibility for Python scripts used in plugin hooks by updating the command invocations to try `python3` first and fall back to `python` if necessary. Additionally, the ecosystem statistics in the `README.md` have been updated to reflect the addition of a new skill.

**Cross-platform Python compatibility:**

* Updated all hook commands in `hooks.json` files across `agent-agentic-os`, `agent-loops`, and `exploration-cycle-plugin` to use `python3 ... || python ...`, ensuring the scripts run correctly regardless of the system's default Python version. [[1]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L9-R9) [[2]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L20-R20) [[3]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L31-R31) [[4]](diffhunk://#diff-90a7be1b5e50ace40e36ad2a9ba49b59eeacdf8ac5684665a52253686167c49aL9-R9) [[5]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL9-R9) [[6]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL20-R20)

**Documentation update:**

* Increased the skills count from 141 to 142 in the ecosystem statistics section of the `README.md`.