### PR TITLE
Fix/hooks cross platform python guards

### DIFF
--- a/plugins/agent-agentic-os/hooks/hooks.json
+++ b/plugins/agent-agentic-os/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/update_memory.py"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_run_metrics.py"
           }
         ]
       }

--- a/plugins/agent-agentic-os/scripts/post_run_metrics.py
+++ b/plugins/agent-agentic-os/scripts/post_run_metrics.py
@@ -55,6 +55,8 @@ def emit_event(project_root: Path, event_data: dict) -> None:
     if not kernel_path.exists():
         # Fallback to appending directly if kernel is missing
         events_log = project_root / "context" / "events.jsonl"
+        if not events_log.parent.exists():
+            return  # Not an Agentic OS project — skip silently
         with open(events_log, "a") as f:
             f.write(json.dumps(event_data) + "\n")
         return
@@ -186,6 +188,9 @@ def main() -> None:
     target_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
     project_root = Path(target_dir).resolve()
     events_log = project_root / "context" / "events.jsonl"
+
+    if not events_log.parent.exists():
+        return  # Not an Agentic OS project — skip silently
 
     counts = _count_events(events_log, correlation_id=args.correlation_id)
     hook_errors = count_hook_errors(project_root)

--- a/plugins/agent-loops/hooks/hooks.json
+++ b/plugins/agent-loops/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/closure_guard.py",
             "description": "Prevents premature session exit without completing the closure sequence (Seal, Persist, Retrospective). Checks for an active loop state file and blocks exit if closure phases are incomplete."
           }
         ]

--- a/plugins/agent-scaffolders/skills/analyze-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/analyze-plugin/SKILL.md
@@ -153,6 +153,8 @@ For each SKILL.md, evaluate:
 - Do they have `--help` documentation?
 - Do they handle errors gracefully?
 - Are they cross-platform compatible?
+- **If the script is wired as a hook**: Does the hooks.json command use `python3 ... || python ...` (not bare `python`) for macOS/Linux + Windows compatibility?
+- **If the script is wired as a hook**: Does `main()` include an early-exit project-type guard so it skips silently in projects that haven't initialized the plugin (e.g. `if not required_dir.exists(): return`)?
 
 ### Phase 4: Pattern Extraction
 

--- a/plugins/agent-scaffolders/skills/audit-plugin/SKILL.md
+++ b/plugins/agent-scaffolders/skills/audit-plugin/SKILL.md
@@ -108,12 +108,13 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/fix_plugin_load_errors.py <plugin_root>
     "SessionStart": [
       {
         "matcher": "",
-        "hooks": [{ "type": "command", "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/script.py" }]
+        "hooks": [{ "type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/script.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/script.py" }]
       }
     ]
   }
 }
 ```
+Note: use `python3 ... || python ...` — not bare `python` — so hooks work on both macOS/Linux and Windows.
 
 **Empty hooks (no hooks needed):**
 ```json
@@ -246,6 +247,10 @@ grep -rn "password\|api_key\|secret\|token" --include="*.md" --include="*.json" 
 # Ensure no hardcoded paths in hook commands or MCP config
 grep -rn "/Users/\|/home/" --include="*.json" --include="*.sh" .
 ```
+
+**Hook script quality (for any `.py` files wired as hooks):**
+- Does the hook command use `python3 ... || python ...` for cross-platform compatibility?
+- Does `main()` have an early-exit project-type guard (e.g. `if not (project_root / "context").exists(): return`) so it skips silently in projects that haven't initialized the plugin?
 
 **Naming conventions:**
 - Plugin name: kebab-case (`my-plugin`, not `MyPlugin` or `my_plugin`)

--- a/plugins/agent-scaffolders/skills/create-hook/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-hook/SKILL.md
@@ -26,6 +26,25 @@ Follow the `create-hook` skill workflow to design and generate a hook configurat
 `hooks.json` entry or SKILL.md frontmatter block with complete hook configuration
 (event, matcher, handler type, command/prompt body, output schema).
 
+## Hook Script Standards
+
+When generating a Python hook script, always apply these two rules:
+
+**Cross-platform python command** — use `python3 ... || python ...` in hooks.json so the hook works on both macOS/Linux (python3) and Windows (python):
+```json
+{ "type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/script.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/script.py" }
+```
+
+**Project-type guard** — hooks run in every project, not just ones that have initialized this plugin. Add an early-exit guard at the top of `main()` so the script skips silently in projects that lack the required context:
+```python
+def main():
+    project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    if not (project_root / "context").exists():
+        return  # Not an initialized project — skip silently
+    ...
+```
+Adapt the guard to whatever directory/file your hook requires (e.g. `.agent/`, `context/os-state.json`).
+
 ## Edge Cases
 
 - If `$ARGUMENTS` is empty: begin with the event selection question in Phase 1

--- a/plugins/exploration-cycle-plugin/hooks/hooks.json
+++ b/plugins/exploration-cycle-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py || python ${CLAUDE_PLUGIN_ROOT}/hooks/session_end.py"
           }
         ]
       }


### PR DESCRIPTION
This pull request improves cross-platform compatibility and robustness for Python hook scripts in several plugins. The main changes ensure that hooks run correctly on both macOS/Linux and Windows by updating how Python is invoked, and add early-exit guards to hook scripts so they skip silently when the required project context is missing. Additionally, documentation is updated to reflect these standards.

**Cross-platform compatibility improvements:**

* Updated all `hooks.json` files in relevant plugins (such as `agent-agentic-os`, `agent-loops`, and `exploration-cycle-plugin`) to use `python3 ... || python ...` instead of just `python` when invoking hook scripts, ensuring hooks work on both macOS/Linux and Windows. [[1]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L9-R9) [[2]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L20-R20) [[3]](diffhunk://#diff-9120bd37386146518f1a0ecec13956ef7efd6039fc22c792b24013847d11f0e9L31-R31) [[4]](diffhunk://#diff-90a7be1b5e50ace40e36ad2a9ba49b59eeacdf8ac5684665a52253686167c49aL9-R9) [[5]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL9-R9) [[6]](diffhunk://#diff-980c122160084affb53fbbbcd05f3480baad7b955b5b48973ba549d450921a3aL20-R20) [[7]](diffhunk://#diff-2ba27075b5126b7fd72c21762390ed8fea148ee5eae43f31fe401040eb010726L111-R117)

**Robustness and error handling:**

* Added early-exit guards to hook scripts (e.g., in `post_run_metrics.py`) so they silently skip execution when the required project directories (like `context/`) do not exist, preventing errors in projects that haven't initialized the plugin. [[1]](diffhunk://#diff-b35795f5255714135ca94662b076f78ed3138ae5e21aea14c9de639b329360f2R58-R59) [[2]](diffhunk://#diff-b35795f5255714135ca94662b076f78ed3138ae5e21aea14c9de639b329360f2R192-R194)

**Documentation updates:**

* Updated skill documentation (`SKILL.md` files) to instruct developers to use the cross-platform Python command in hooks and to include early-exit guards in hook scripts. This guidance is now present in scaffolder and audit skills, as well as in the hook creation workflow. [[1]](diffhunk://#diff-dcd2aa771e4f7330246cec79a6cc71d55a9f3982b22b93e5bce79409b8250c76R156-R157) [[2]](diffhunk://#diff-2ba27075b5126b7fd72c21762390ed8fea148ee5eae43f31fe401040eb010726R251-R254) [[3]](diffhunk://#diff-db713f17fa3a8724a0863b970fb28c742dab7077d2c5113da6c5871b1b6db6bcR29-R47)

These changes make hook scripts more reliable and easier to use across different environments.