### PR TITLE
fix(self-evolution): round 5.1 — distinct friction.resolved type, cal…

### DIFF
--- a/.agent/rules/self-evolution-policy.md
+++ b/.agent/rules/self-evolution-policy.md
@@ -124,4 +124,6 @@ Each Map Debt entry must include:
 
 **Aging rule:** At Phase 0 read, count completed cycles since entry's Cycle ID. If an `OPEN`
 entry is older than 3 completed cycles, auto-escalate before starting new work.
+If the entry's Cycle ID is from a prior session (not in current `events.jsonl`), fall back
+to the Logged date: auto-escalate if `(today - Logged) > 14 days`.
 **Repeat = YES:** must escalate on next encounter — no further deferral permitted.

--- a/plugins/agent-agentic-os/skills/os-improvement-loop/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-improvement-loop/SKILL.md
@@ -315,7 +315,7 @@ event before `task.complete` or `loop.close`.
 
 ```bash
 python "$KERNEL_PY" emit_event \
-  --agent INNER_AGENT --type friction --action friction.resolved \
+  --agent INNER_AGENT --type friction.resolved --action resolved \
   --correlation-id "$CID" \
   --summary "friction-id:<original-timestamp> outcome:FIX|MAP_DEBT|ESCALATE artifact:<path>"
 ```
@@ -325,8 +325,9 @@ Valid outcomes:
 - `MAP_DEBT` — recorded in `<plugin>/references/map-debt.md`
 - `ESCALATE` — user escalation required
 
-Stage 4.0 verifies: for each `friction` event in this cycle, exactly one `friction.resolved`
-exists with matching `correlation-id`.
+Stage 4.0 verifies by reading two distinct event types:
+- `--type friction` (encountered events) and `--type friction.resolved` (resolution events)
+- Count must match: every open must have exactly one close with matching `correlation-id`.
 
 ---
 
@@ -527,7 +528,7 @@ Every time INNER_AGENT receives `task.assigned`, it MUST:
 5. If DISCARD: revert edit, note failure in output file, emit `task.complete --status fail`.
 6. Write output to `handoffs/out-${CID}.md`.
 7. **Complete the Post-Run Self-Assessment Survey** (see Stage 4.2).
-8. **Before emitting `task.complete`**, close every friction event emitted this cycle with a `friction.resolved` event (outcome: `FIX`, `MAP_DEBT`, or `ESCALATE`).
+8. **Before emitting `task.complete`**, close every friction event emitted this cycle with a `type: friction.resolved` event (outcome: `FIX`, `MAP_DEBT`, or `ESCALATE`).
 9. Emit `task.complete` including score, output path, and survey path in summary.
 
 ### PEER_AGENT Eval Obligation
@@ -578,17 +579,16 @@ Before `loop.close` may be emitted, ORCHESTRATOR must verify all friction events
 cycle are resolved. A loop cannot close with unhandled friction.
 
 ```bash
-# Read friction events for this cycle
-python "$KERNEL_PY" read_events --type friction --correlation-id "$CYCLE_ID"
+# Count friction encounters vs resolutions for this cycle
+OPEN=$(python "$KERNEL_PY" read_events --type friction --correlation-id "$CYCLE_ID" | python -c "import sys,json; print(len(json.load(sys.stdin)))")
+CLOSED=$(python "$KERNEL_PY" read_events --type friction.resolved --correlation-id "$CYCLE_ID" | python -c "import sys,json; print(len(json.load(sys.stdin)))")
+# Pass only if OPEN == CLOSED
 ```
 
-For each friction event, verify exactly one resolution exists:
-- Fixed and Map updated (`friction.resolved` with `outcome: FIX`)
-- Logged as Map Debt (`friction.resolved` with `outcome: MAP_DEBT`)
-- Escalated to user (`friction.resolved` with `outcome: ESCALATE`)
+For each `friction` event, verify exactly one `friction.resolved` event exists with matching
+`correlation-id`. Valid resolutions: `outcome: FIX`, `MAP_DEBT`, or `ESCALATE`.
 
-If any friction event has no corresponding `friction.resolved`, do **not** emit `loop.close`.
-Resolve or escalate before proceeding to 4.1.
+If `OPEN != CLOSED`, do **not** emit `loop.close`. Resolve or escalate before proceeding to 4.1.
 
 ### 4.1 Emit loop.close
 

--- a/plugins/agent-agentic-os/skills/self-evolution/SKILL.md
+++ b/plugins/agent-agentic-os/skills/self-evolution/SKILL.md
@@ -113,12 +113,7 @@ Otherwise, using the error message, stack trace, and context, classify into exac
 ### Tier 0 — Friction / Workaround
 > "The task completed, but the system did not improve."
 
-**Signals:**
-- Agent bypassed an existing script, skill, sub-agent, or helper
-- Agent manually performed work that an existing repo capability should handle
-- Agent encountered ambiguity and guessed instead of improving instructions
-- Agent noticed an awkward or error-prone workflow but did not update The Map
-- Agent used a temporary workaround
+**Definition + signals:** see `.agent/rules/self-evolution-policy.md` § Tier 0.
 
 **Response:** If small + inside allowed edit boundaries — patch now, update The Map. If not safe or small — log as Map Debt (see Phase 7). If repeated or blocking — escalate.
 
@@ -308,6 +303,8 @@ the evolution log is the immutable audit trail. Do not double-count: one write t
 
 **Aging rule:** At Phase 0 read, count completed cycles since the entry's `Cycle ID`. If an
 `OPEN` entry is older than 3 completed cycles, auto-escalate before starting new work.
+If the Cycle ID is from a prior session (not in current `events.jsonl`), fall back to
+the Logged date: auto-escalate if `(today - Logged) > 14 days`.
 Set `Status` to `RESOLVED` when fixed, `ESCALATED` when escalated to the user.
 
 If the log file doesn't exist yet, create it with the header:


### PR DESCRIPTION
…endar aging fallback

- friction.resolved is now a distinct event type (--type friction.resolved --action resolved) rather than an action on type:friction — symmetric with task.assigned/task.complete; Stage 4.0 now reads two separate event streams (friction vs friction.resolved) and compares counts, avoiding ambiguous mixed result sets
- Map Debt aging: adds calendar-day fallback for cross-session entries — if Cycle ID is not in current events.jsonl, auto-escalate if (today - Logged) > 14 days; applied to both self-evolution-policy.md and self-evolution/SKILL.md
- Tier 0 signals in SKILL.md Phase 1 collapsed to pointer → .agent/rules/self-evolution-policy.md (rule file is canonical; skill keeps the response protocol only)
- INNER_AGENT step 8 updated to reference friction.resolved type explicitly