### PR TITLE
chore(dev-utils): remove rsvp-reading skill and rsvp-comprehension-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Nine standalone plugins consolidated into one. All tools are stateless and self-
 
 **Skills (12):** [`adr-management`](plugins/dev-utils/skills/adr-management/SKILL.md) · [`coding-conventions-agent`](plugins/dev-utils/skills/coding-conventions-agent/SKILL.md) · [`context-bundler`](plugins/dev-utils/skills/context-bundler/SKILL.md) · [`convert-mermaid`](plugins/dev-utils/skills/convert-mermaid/SKILL.md) · [`hf-init`](plugins/dev-utils/skills/hf-init/SKILL.md) · [`hf-upload`](plugins/dev-utils/skills/hf-upload/SKILL.md) · [`humanize`](plugins/dev-utils/skills/humanize/SKILL.md) · [`link-checker-agent`](plugins/dev-utils/skills/link-checker-agent/SKILL.md) · [`optimize-context`](plugins/dev-utils/skills/optimize-context/SKILL.md) · [`red-team-bundler`](plugins/dev-utils/skills/red-team-bundler/SKILL.md) · [`symlink-manager`](plugins/dev-utils/skills/symlink-manager/SKILL.md) · [`task-agent`](plugins/dev-utils/skills/task-agent/SKILL.md)
 
-**Agents (3):** `coding-conventions-agent` · `link-checker-agent` · `rsvp-comprehension-agent`
+**Agents (2):** `coding-conventions-agent` · `link-checker-agent`
 
 #### plugin-manager — Ecosystem Sync
 

--- a/plugins/dev-utils/agents/rsvp-comprehension-agent.md
+++ b/plugins/dev-utils/agents/rsvp-comprehension-agent.md
@@ -1,1 +1,0 @@
-../skills/rsvp-comprehension-agent/SKILL.md

--- a/plugins/dev-utils/plugin.yaml
+++ b/plugins/dev-utils/plugin.yaml
@@ -23,8 +23,6 @@ skills:
   - humanize
   - link-checker-agent
   - red-team-bundler
-  - rsvp-comprehension-agent
-  - rsvp-reading
   - optimize-context
   - symlink-manager
   - task-agent

--- a/symlinks.json
+++ b/symlinks.json
@@ -2312,54 +2312,6 @@
       "description": ""
     },
     {
-      "src": "plugins/dev-utils/references/token-stream-schema.md",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/references/token-stream-schema.md",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/references/architecture.md",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/references/architecture.md",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/references/acceptance-criteria.md",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/references/acceptance-criteria.md",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/references/fallback-tree.md",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/references/fallback-tree.md",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/references/diagrams/rsvp-reading-flow.mmd",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/references/diagrams/rsvp-reading-flow.mmd",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/execute.py",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/scripts/execute.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/parse_document.py",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/scripts/parse_document.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/orp_engine.py",
-      "dst": "plugins/dev-utils/skills/rsvp-reading/scripts/orp_engine.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
       "src": "ADRs/005_plugin_separation_of_concerns_and_loose_coupling.md",
       "dst": "plugins/dev-utils/skills/symlink-manager/references/005_plugin_separation_of_concerns_and_loose_coupling.md",
       "strategy": "symlink",


### PR DESCRIPTION
Both were dead: rsvp-reading had no source scripts (never committed), rsvp-comprehension-agent agent file pointed to a non-existent SKILL.md.

- Delete plugins/dev-utils/agents/rsvp-comprehension-agent.md
- Remove rsvp-comprehension-agent and rsvp-reading from plugin.yaml skills list
- Remove Agents (3) rsvp-comprehension-agent from README.md (now Agents (2))
- Remove 8 rsvp symlink entries from symlinks.json
- symlink diagnose: 0 broken links