### PR TITLE
Feat/evolution policy ecosystem audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 146 Skills · 54 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 146 Skills · 53 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026) · v1.5 — CLI Agents major update (June 2026)

--- a/plugins/agent-scaffolders/skills/create-skill/SKILL.md
+++ b/plugins/agent-scaffolders/skills/create-skill/SKILL.md
@@ -7,7 +7,7 @@ description: >
   as needed, and runs a discovery interview to capture name, purpose, and trigger phrases
   before writing any files. Use when the user says "create a new skill", "scaffold a skill",
   "generate a skill", "new skill setup", or "make a skill directory". Does not handle
-  content improvement for existing skills — that is handled by os-skill-improvement.
+  content improvement for existing skills — that is handled by os-improvement-loop.
 argument-hint: "[skill-name or use-case description]"
 allowed-tools: Bash, Read, Write
 ---


### PR DESCRIPTION
This pull request makes minor updates to documentation for accuracy and clarity. The most important changes are:

Ecosystem statistics update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the number of Sub-Agents from 54 to 53 to reflect the current ecosystem scale.

Skill improvement reference update:

* [`plugins/agent-scaffolders/skills/create-skill/SKILL.md`](diffhunk://#diff-cf506e8b5091eed0e51ea4bbba9d6af290ca3582d9cab6108898bfff9a5b7b61L10-R10): Changed the reference from `os-skill-improvement` to `os-improvement-loop` for the skill responsible for content improvement in existing skills.