### PR TITLE
docs(ecosystem): auto-update plugin/skill counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 151 Skills · 52 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 147 Skills · 50 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026) · v1.5 — CLI Agents major update (June 2026)


### PR DESCRIPTION
This pull request updates the ecosystem statistics in the `README.md` file to reflect the current number of plugins, skills, and sub-agents.

- Documentation update:
  * Updated the ecosystem statistics in `README.md` to show 11 Plugins, 147 Skills, and 50 Sub-Agents, reflecting the latest counts.