### PR TITLE
fix(cli-agents): add execution contract, backend capability matrix, K…

### DIFF
--- a/plugins/cli-agents/references/backend-capabilities.md
+++ b/plugins/cli-agents/references/backend-capabilities.md
@@ -1,0 +1,49 @@
+# Backend Capability Matrix
+
+Agent MUST select backend based on task type. Do NOT use the default blindly.
+
+## Capability Table
+
+| CLI | Binary | Strength | Weakness | Use For |
+|---|---|---|---|---|
+| `claude` | `claude` | Highest reasoning, best instruction following | Cost, interactive-only without `--yolo` | Complex analysis, nuanced content, open-ended reasoning |
+| `copilot` | `copilot` | Multi-model selection, code-focused, IDE-native | Dynamic prompt injection kills KV cache; AI Credits cost | Code review, multi-file generation, structured output |
+| `agy` | `agy` | Frontier Gemini (3.5 Flash+), large context | Rate limits, `--dangerously-skip-permissions` required for headless | Long context tasks, frontier Gemini models |
+| `codex` | `codex` | Code transformation, OpenAI models | Weaker language reasoning than Claude | Code-only tasks, diff generation, code analysis |
+| `llama` | `llama-server` (HTTP) | Fastest (~2s), zero API cost, private | Weaker reasoning than cloud models | Bounded loops, high-frequency local tasks, private data |
+| `gemini` | `gemini` | Older Gemini models, no AI Credits | Deprecated for frontier work — use `agy` | Cost-efficient older Gemini only (2.5-pro, 3-flash-preview) |
+
+## Isolation Behavior Per Backend
+
+These CLIs are **not interchangeable** from an isolation standpoint:
+
+| CLI | Headless flag | Isolation mechanism |
+|---|---|---|
+| `claude` | `--no-permissions` | Suppresses tool calls |
+| `copilot` | `--yolo` | Enables tool access; absent = read-only |
+| `agy` | `--dangerously-skip-permissions` | Suppresses permission prompts |
+| `codex` | stdin-native | Prompt via stdin; tool flags vary |
+| `llama` | N/A | Pure HTTP POST — no tool concept |
+| `gemini` | `-y` | Headless mode |
+
+When `run_agent.py --isolated` is set, dangerous flags are suppressed and a safety
+footer is appended. This normalizes isolation across backends — but the underlying
+mechanisms remain different. Do not assume equivalent behavior.
+
+## Quality vs Cost Positioning
+
+| Need | Recommended CLI | Reason |
+|---|---|---|
+| Fastest output | `llama` | Direct HTTP, ~2s, local |
+| Cheapest cloud | `copilot` with `gpt-5-mini` | Included model, no credit cost |
+| Best code analysis | `codex` or `copilot` | Code-trained models |
+| Best reasoning | `claude` | Highest reasoning quality |
+| Long context | `agy` (Gemini 3.5 Flash+) | 1M+ token window |
+| Multi-perspective | Run same task on two CLIs, route through `debate-synthesizer` | |
+
+## Capability Gaps — What NOT to Assume
+
+- All backends support tool use the same way → **they do not**
+- Model quality is equivalent across backends for the same task → **it is not**
+- Output structure (markdown, code blocks) is consistent → **it is not**
+- A backend that worked yesterday has the same API surface → **verify with heartbeat first**

--- a/plugins/cli-agents/references/execution-contract.md
+++ b/plugins/cli-agents/references/execution-contract.md
@@ -1,0 +1,75 @@
+# CLI Agents: Execution Contract
+
+Non-negotiable behavioral rules for all cli-agents workflows. These rules exist because
+the plugin provides the execution layer — drift here cascades to every workflow above it.
+
+---
+
+## Rule 1 — One Backend Per Task
+
+Every task executes against **exactly one backend**. The choice is made before dispatch.
+
+- Do NOT switch CLI automatically if a backend fails.
+- Do NOT silently retry on a different backend without explicit user instruction.
+- Backend failure → halt, surface the error, log to `references/map-debt.md`.
+
+```
+backend selected → task dispatched → success or halt
+                                        ↓
+                              log failure, surface to caller
+```
+
+## Rule 2 — Mandatory Validation Orchestration
+
+Validation agents exist but only produce value when actually invoked. This table is
+the trigger spec — skip any row and you've violated the contract.
+
+| Situation | Required agents |
+|---|---|
+| Any output affecting production code | `output-validator` |
+| Output quality uncertain after a single pass | `self-critic` |
+| Code review task | primary reviewer → `output-validator` |
+| Architecture / high-risk decision | `architect-review` → `red-team-reviewer` → `debate-synthesizer` |
+| Two agents produce conflicting output | `debate-synthesizer` |
+| Risk level high (security, data, infra) | `red-team-reviewer` (optionally) |
+
+Skipping a required agent when its trigger fires is a contract violation.
+
+## Rule 3 — Security Contract (Isolation)
+
+Isolation policy is global — not per-adapter.
+
+**When `--isolated` is set:**
+- Dangerous permission flags are suppressed for all CLIs (`--yolo`, `--dangerously-skip-permissions`)
+- Safety footer is appended to all prompts
+- Use for all analysis tasks (reviews, audits, output generation)
+
+**When NOT isolated (task dispatch with tool access):**
+- Requires explicit user instruction or approval
+- Agent must confirm intent before enabling tools
+
+The default in `run_agent.py` is non-isolated for task dispatch; use `--isolated` for
+analysis passes. Do not invert this default silently.
+
+## Rule 4 — No Workarounds
+
+If any of the following occur:
+
+- Backend call fails
+- Output is empty or clearly below quality threshold
+- A workaround was attempted to bypass a constraint or failure
+
+The agent MUST:
+
+1. **Halt** — do not proceed as if successful
+2. **Log** — add a row to `references/map-debt.md` (Tier 0 Friction)
+3. **Surface** — report the failure explicitly to the caller
+
+Workarounds = Tier 0 Friction. This is a self-evolution event, not a soft warning.
+
+---
+
+## Backend Selection (non-negotiable)
+
+See `references/backend-capabilities.md` for the capability matrix. Agent MUST
+select backend based on task type — do not default blindly.

--- a/plugins/cli-agents/scripts/conductor.py
+++ b/plugins/cli-agents/scripts/conductor.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """
-conductor.py
-============
-Unified CLI Conductor script. Orchestrates task delegation to Claude, Copilot, and Gemini
-CLI adapters with path validation, default isolation constraints, and safe file lifecycles.
+conductor.py — DEPRECATED
+=========================
+Use run_agent.py instead. conductor.py predates the multi-backend run_agent.py router
+and supports only claude/copilot/gemini via adapter classes. run_agent.py covers all
+backends (claude, copilot, agy, codex, llama, gemini) with a unified argparse interface,
+hub-and-spoke symlinks into each skill, and 76+ tests.
+
+This file is retained for backward compatibility only. Do not add new functionality here.
 """
 
 import os

--- a/plugins/cli-agents/scripts/kv_cache_orchestrator.py
+++ b/plugins/cli-agents/scripts/kv_cache_orchestrator.py
@@ -12,6 +12,16 @@ Architectural pattern adapted from antirez/ds4 ds4_kvstore.c:
 
 Integration path: routing_proxy.py calls check_cache() → restore_slot() before
 forwarding, then save_slot() in a background thread after the stream completes.
+
+Operational Limitations (read before assuming cache benefits):
+  - Cache key = SHA-256 of system message content ONLY (see cache_key()).
+  - Any change to the system prompt = cache miss. Stable system prompts required.
+  - CLI tools (Copilot, Claude Code, Agy) inject dynamic context into the system
+    prompt on every call — effective hit rate for CLI-driven sessions is near zero.
+  - Do NOT rely on KV cache for: CLI-driven sessions, multi-agent workflows,
+    or any session where system prompt varies per call.
+  - KV cache is effective only for: routing_proxy.py (Mode A) interactive sessions
+    where the same system prompt is reused across many turns.
 """
 
 import hashlib

--- a/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
+++ b/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
@@ -10,6 +10,17 @@ description: >
 allowed-tools: Bash, Read, Write
 ---
 
+## Execution Contract
+
+> **See `references/execution-contract.md` (full rules) and `references/backend-capabilities.md` (backend selection).**
+>
+> Key rules: (1) One backend per task — no silent fallback. (2) Run `output-validator` or
+> `self-critic` when output quality is uncertain. (3) Architecture/high-risk tasks require
+> `architect-review` → `red-team-reviewer` → `debate-synthesizer`. (4) Backend failure →
+> halt and log to `references/map-debt.md`. No workarounds.
+
+---
+
 ## Identity: The Antigravity Sub-Agent Dispatcher (Frontier: Gemini 3.5 Flash+)
 
 You dispatch tasks to Google Gemini frontier models via the `agy` binary.

--- a/plugins/cli-agents/skills/copilot-cli-agent/SKILL.md
+++ b/plugins/cli-agents/skills/copilot-cli-agent/SKILL.md
@@ -8,6 +8,17 @@ description: >
 allowed-tools: Bash, Read, Write
 ---
 
+## ⚖️ Execution Contract
+
+> **See `references/execution-contract.md` (full rules) and `references/backend-capabilities.md` (backend selection).**
+>
+> Key rules: (1) One backend per task — no silent fallback. (2) Run `output-validator` or
+> `self-critic` when output quality is uncertain. (3) Architecture/high-risk tasks require
+> `architect-review` → `red-team-reviewer` → `debate-synthesizer`. (4) Backend failure →
+> halt and log to `references/map-debt.md`. No workarounds.
+
+---
+
 ## 🎭 Identity: The Sub-Agent Dispatcher (Standard: gpt-5-mini)
 
 You, the Antigravity agent, dispatch specialized analysis tasks to Copilot CLI sub-agents.


### PR DESCRIPTION
…V cache limitations

P1-1: references/execution-contract.md — one backend per task, no silent fallback,
      halt-and-log on failure; wires self-evolution rule (P2-7)
P1-2: execution-contract.md — mandatory orchestration table: when to invoke
      output-validator, self-critic, red-team-reviewer, debate-synthesizer
P1-3: references/backend-capabilities.md — capability matrix (llama/codex/copilot/
      claude/agy/gemini), isolation behavior diff, quality/cost positioning
P1-4: kv_cache_orchestrator.py — Operational Limitations docstring: cache key =
      system messages only; CLI dynamic injection = near-zero hit rate; scope
      correctly to Mode A (routing_proxy) only
P2-5: conductor.py — deprecation header; use run_agent.py instead Enforcement: copilot-cli-agent/SKILL.md, agy-cli-agent/SKILL.md — contract
      reference block added above identity section