### PR TITLE
feat(cli-agents): P1 fixes — AI Credits billing, model catalog, agy Flash/Pro docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,18 +213,21 @@ symlink-manager, task-agent
 
 ### Copilot CLI delegation pattern (canonical)
 
-> **June 2026:** `gpt-5-mini` remains included (no AI Credits cost). All other models consume credits per token. Plan first — fewer requests saves quality, not necessarily credits. See `cli-agents/skills/copilot-cli-agent` for updated model table.
+> **June 2026:** All Copilot models bill per AI Credits (token-based). Model selection should use
+> `plugins/cli-agents/references/copilot-models.json` — see the `strategy` field for tier recommendations
+> and `cost_tiers` for cheapest-to-most-expensive groupings. Plan first — fewer requests saves credits.
 
 ```bash
-# 1. Heartbeat (included model — always first, zero credit cost)
+# 1. Heartbeat — use cheapest model (see copilot-models.json strategy.heartbeat)
 python3 plugins/cli-agents/skills/copilot-cli-agent/scripts/run_agent.py \
-  /dev/null /dev/null temp/heartbeat.md "HEARTBEAT CHECK: Respond HEARTBEAT_OK only."
+  /dev/null /dev/null temp/heartbeat.md "HEARTBEAT CHECK: Respond HEARTBEAT_OK only." \
+  gpt-5.4-nano
 
-# 2. Dispatch (plan well, batch for coherence)
+# 2. Dispatch — pick model from copilot-models.json strategy field for the task tier
 python3 plugins/cli-agents/skills/copilot-cli-agent/scripts/run_agent.py \
   /dev/null tasks/todo/copilot_prompt_<task>.md temp/copilot_output_<task>.md \
   "Generate all files exactly as specified. Use the Write tool to write files directly." \
-  claude-sonnet-4.6
+  claude-sonnet-4.6  # strategy.complex — see copilot-models.json
 
 # 3. Verify output before claiming complete
 wc -l temp/copilot_output_<task>.md  # expect 100+ lines for multi-file output

--- a/plugins/agent-loops/references/cheapest_models.json
+++ b/plugins/agent-loops/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest OpenAI model (20 cr/1M input, 125 cr/1M output)"
   },
   "agy": {
-    "model": "gemini-3.1-pro",
+    "model": "gemini-3.5-flash",
     "cost": "Paid (Per-token)",
-    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
+    "description": "Flash: faster, cheaper/token, optimized for agentic/tool-use tasks. Use Low thinking level."
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/agent-loops/references/cheapest_models.json
+++ b/plugins/agent-loops/references/cheapest_models.json
@@ -5,9 +5,9 @@
     "description": "Local inference on port 8089"
   },
   "copilot": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-nano",
     "cost": "Paid (AI Credits)",
-    "description": "Standard low-cost reasoning tier"
+    "description": "Cheapest OpenAI model (20 cr/1M input, 125 cr/1M output)"
   },
   "agy": {
     "model": "gemini-3.5-flash",
@@ -15,9 +15,9 @@
     "description": "Antigravity CLI (replaces old gemini CLI)"
   },
   "claude": {
-    "model": "claude-haiku-4-5",
+    "model": "claude-haiku-4.5",
     "cost": "Paid (Per-token)",
-    "description": "High context window ($1/$5 per MTok)"
+    "description": "Cheapest Anthropic model ($1/$5 per MTok input/output)"
   },
   "codex": {
     "model": "gpt-5-mini",

--- a/plugins/agent-loops/references/cheapest_models.json
+++ b/plugins/agent-loops/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest OpenAI model (20 cr/1M input, 125 cr/1M output)"
   },
   "agy": {
-    "model": "gemini-3.5-flash",
-    "cost": "Paid (Per-token / Pro quotas)",
-    "description": "Antigravity CLI (replaces old gemini CLI)"
+    "model": "gemini-3.1-pro",
+    "cost": "Paid (Per-token)",
+    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/agent-loops/scripts/swarm_run.py
+++ b/plugins/agent-loops/scripts/swarm_run.py
@@ -298,7 +298,7 @@ def execute_worker(
         # Apply intelligent default models if the 'haiku' placeholder or no model is provided
         effective_model = model
         if engine.lower() == "copilot" and (not model or model == "haiku" or model.startswith("claude")):
-            effective_model = _load_cheapest_model("copilot", "gpt-5-mini")
+            effective_model = _load_cheapest_model("copilot", "gpt-5.4-nano")
         elif engine.lower() == "agy" and (not model or model == "haiku" or model.startswith("claude")):
             effective_model = _load_cheapest_model("agy", "gemini-3.5-flash")
 

--- a/plugins/agent-memory/references/cheapest_models.json
+++ b/plugins/agent-memory/references/cheapest_models.json
@@ -11,9 +11,9 @@
     },
     {
       "cli": "copilot",
-      "model": "gpt-5-mini",
+      "model": "gpt-5.4-nano",
       "cost_tier": "paid_per_token",
-      "cost_note": "Copilot Pro free tier ended June 2026. Billed per AI Credits.",
+      "cost_note": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output. All models billed per AI Credits (token-based, June 2026).",
       "deprecated": false
     },
     {
@@ -33,9 +33,9 @@
     },
     {
       "cli": "claude",
-      "model": "claude-haiku-4-5",
+      "model": "claude-haiku-4.5",
       "cost_tier": "paid_per_token",
-      "cost_note": "$1/MTok input, $5/MTok output.",
+      "cost_note": "$1/MTok input, $5/MTok output. Cheapest Anthropic model.",
       "deprecated": false
     },
     {

--- a/plugins/agent-memory/references/cheapest_models.json
+++ b/plugins/agent-memory/references/cheapest_models.json
@@ -18,9 +18,9 @@
     },
     {
       "cli": "agy",
-      "model": "gemini-3.5-flash",
+      "model": "gemini-3.1-pro",
       "cost_tier": "paid_per_token",
-      "cost_note": "Antigravity CLI — replacement for deprecated standalone gemini CLI.",
+      "cost_note": "Cheapest real-world agentic model. 3.5 Flash burns 3-5x more tokens via Thought Preservation.",
       "deprecated": false
     },
     {

--- a/plugins/agent-memory/references/cheapest_models.json
+++ b/plugins/agent-memory/references/cheapest_models.json
@@ -18,9 +18,9 @@
     },
     {
       "cli": "agy",
-      "model": "gemini-3.1-pro",
+      "model": "gemini-3.5-flash",
       "cost_tier": "paid_per_token",
-      "cost_note": "Cheapest real-world agentic model. 3.5 Flash burns 3-5x more tokens via Thought Preservation.",
+      "cost_note": "Flash: faster (4x tokens/sec), cheaper/token, optimized for agentic/tool-use/coding tasks. Use Low thinking level to control cost.",
       "deprecated": false
     },
     {

--- a/plugins/cli-agents/references/agy-models.json
+++ b/plugins/cli-agents/references/agy-models.json
@@ -6,44 +6,22 @@
     "notes": [
       "agy is the sole Gemini CLI since the standalone gemini binary retired June 18 2026.",
       "Thinking level (Low/Medium/High) is part of the model identity in agy — see display_name.",
-      "List price alone is misleading: Gemini 3.5 Flash's Thought Preservation feature carries reasoning context forward across turns, inflating real-world token spend 3-5x vs 3.1 Pro.",
-      "Gemini 3.1 Flash-Lite not available in agy as of 2026-06-28 — cheapest available model is Gemini 3.1 Pro (Low).",
-      "Model IDs for --model flag: use display_name exactly (e.g. 'Gemini 3.1 Pro (Low)') or kebab shortform where documented."
+      "Flash is designed for speed, coding, tool use, and agentic workflows. Pro is for deep reasoning.",
+      "Flash is ~4x faster (tokens/sec) and cheaper per token than Pro.",
+      "Flash with high thinking levels can inflate tokens via Thought Preservation — use Low for CLI dispatch.",
+      "Gemini 3.1 Flash-Lite not available in agy as of 2026-06-28."
     ]
   },
   "models": [
-    {
-      "display_name": "Gemini 3.1 Pro (Low)",
-      "cli_id": "gemini-3.1-pro",
-      "thinking_level": "low",
-      "status": "available",
-      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
-      "avg_turns_per_agentic_task": 26,
-      "avg_context_per_task_k": 650,
-      "recommendation": "Default — cheapest real-world agentic cost",
-      "notes": "Low thinking strips excessive reasoning loops. Best cost/quality ratio for CLI dispatch tasks."
-    },
-    {
-      "display_name": "Gemini 3.1 Pro (High)",
-      "cli_id": "gemini-3.1-pro-high",
-      "thinking_level": "high",
-      "status": "available",
-      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
-      "recommendation": "Use for complex multi-step reasoning tasks",
-      "notes": "Same list price as Low; more expensive in practice due to higher token throughput per turn."
-    },
     {
       "display_name": "Gemini 3.5 Flash (Low)",
       "cli_id": "gemini-3.5-flash-low",
       "thinking_level": "low",
       "status": "available",
       "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
-      "avg_turns_per_agentic_task": 39,
-      "avg_context_per_task_k": 1400,
-      "recommendation": "Avoid for CLI dispatch loops",
-      "notes": "Lower list price but Thought Preservation still inflates tokens even at Low. 3-5x more expensive than 3.1 Pro in practice."
+      "speed_relative": "4x faster than Pro",
+      "recommendation": "Default — cheapest per token, optimized for agentic/coding/tool-use tasks",
+      "notes": "Low thinking avoids Thought Preservation token inflation. Best choice for CLI dispatch loops."
     },
     {
       "display_name": "Gemini 3.5 Flash (Medium)",
@@ -51,10 +29,9 @@
       "thinking_level": "medium",
       "status": "available",
       "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
-      "recommendation": "Legacy default — do not use",
-      "notes": "Previous cheapest_models.json default. Replaced by gemini-3.1-pro. Avoid: token burn from agentic loops."
+      "speed_relative": "4x faster than Pro",
+      "recommendation": "Standard dispatch — good balance of reasoning and cost",
+      "notes": "Legacy cheapest_models.json default. Thought Preservation active but manageable. Monitor token spend on long loops."
     },
     {
       "display_name": "Gemini 3.5 Flash (High)",
@@ -62,10 +39,29 @@
       "thinking_level": "high",
       "status": "available",
       "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
-      "recommendation": "Do not use",
-      "notes": "Maximum token inflation. Only viable for single-shot reasoning tasks, not CLI loops."
+      "speed_relative": "4x faster than Pro",
+      "recommendation": "Single-shot deep tasks only — not for loops",
+      "notes": "Maximum Thought Preservation — token inflation risk. Avoid in high-frequency CLI dispatch."
+    },
+    {
+      "display_name": "Gemini 3.1 Pro (Low)",
+      "cli_id": "gemini-3.1-pro",
+      "thinking_level": "low",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
+      "speed_relative": "1x (baseline)",
+      "recommendation": "Deep reasoning, architecture decisions, expert-level analysis",
+      "notes": "Heavier flagship model. Superior at abstract reasoning, ARC-AGI, long-context comprehension. Slower and more expensive per token than Flash."
+    },
+    {
+      "display_name": "Gemini 3.1 Pro (High)",
+      "cli_id": "gemini-3.1-pro-high",
+      "thinking_level": "high",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
+      "speed_relative": "1x (baseline)",
+      "recommendation": "Most demanding reasoning tasks only",
+      "notes": "Maximum reasoning depth. High cost. Use for critical architecture reviews or complex novel problems."
     },
     {
       "display_name": "Claude Sonnet 4.6 (Thinking)",
@@ -73,9 +69,8 @@
       "thinking_level": "thinking",
       "status": "available",
       "pricing_usd_per_1m": null,
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
-      "recommendation": "High-value tasks requiring Anthropic quality via agy",
+      "speed_relative": null,
+      "recommendation": "Anthropic quality via agy when claude-cli-agent unavailable",
       "notes": "Premium tier. Use claude-cli-agent for direct Claude access if available."
     },
     {
@@ -84,10 +79,9 @@
       "thinking_level": "thinking",
       "status": "available",
       "pricing_usd_per_1m": null,
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
+      "speed_relative": null,
       "recommendation": "Critical tasks only",
-      "notes": "Highest tier available in agy. Very expensive."
+      "notes": "Highest tier in agy. Very expensive."
     },
     {
       "display_name": "GPT-OSS 120B (Medium)",
@@ -95,31 +89,41 @@
       "thinking_level": "medium",
       "status": "available",
       "pricing_usd_per_1m": null,
-      "avg_turns_per_agentic_task": null,
-      "avg_context_per_task_k": null,
+      "speed_relative": null,
       "recommendation": "OpenAI OSS tasks via agy",
       "notes": "Large OpenAI OSS model. Use copilot-cli-agent for direct Copilot access."
     }
   ],
+  "flash_vs_pro": {
+    "flash_wins": [
+      "Speed (4x faster tokens/sec)",
+      "Per-token cost (cheaper)",
+      "Agentic tool use, MCP, terminal tasks",
+      "Coding: edit-test loops, Terminal-Bench",
+      "API handling",
+      "Multimodal perception",
+      "Max output tokens (65,536 vs 32,768)"
+    ],
+    "pro_wins": [
+      "Deep abstract reasoning (ARC-AGI)",
+      "Architecture planning and final code review",
+      "Complex multi-step logical deduction",
+      "Specialized academic / expert exams",
+      "Long-context comprehension"
+    ],
+    "guidance": "Default to Flash for CLI dispatch. Escalate to Pro for reasoning-heavy tasks."
+  },
   "cost_tiers": {
-    "cheapest": ["gemini-3.1-pro"],
-    "moderate": ["gemini-3.1-pro-high", "gemini-3.5-flash-low"],
-    "expensive": ["gemini-3.5-flash", "gemini-3.5-flash-high"],
+    "cheapest": ["gemini-3.5-flash-low", "gemini-3.5-flash"],
+    "moderate": ["gemini-3.5-flash-high", "gemini-3.1-pro"],
+    "expensive": ["gemini-3.1-pro-high"],
     "premium": ["claude-sonnet-4.6-thinking", "claude-opus-4.6-thinking", "gpt-oss-120b"]
   },
   "strategy": {
-    "heartbeat": "gemini-3.1-pro",
-    "default": "gemini-3.1-pro",
-    "complex": "gemini-3.1-pro-high",
+    "heartbeat": "gemini-3.5-flash",
+    "default": "gemini-3.5-flash",
+    "reasoning": "gemini-3.1-pro",
+    "architecture": "gemini-3.1-pro-high",
     "anthropic_quality": "claude-sonnet-4.6-thinking"
-  },
-  "agentic_token_trap": {
-    "description": "Gemini 3.5 Flash's Thought Preservation feature carries reasoning context forward across turns by design. This causes hyper-inflation of input tokens during multi-step CLI operations even when effort is set to Low.",
-    "data": {
-      "gemini_3_5_flash": { "avg_turns": 39, "avg_context_k": 1400, "relative_cost": "3-5x" },
-      "gemini_3_1_pro_low": { "avg_turns": 26, "avg_context_k": 650, "relative_cost": "1x" }
-    },
-    "why_list_price_misleads": "Flash ($1.50/M) appears cheaper than Pro ($2.00/M) on list. In agentic CLI loops, Flash's token inflation makes it 3-5x more expensive per completed task.",
-    "recommendation": "Always use gemini-3.1-pro for CLI dispatch. Reserve Flash models for single-shot or interactive use only."
   }
 }

--- a/plugins/cli-agents/references/agy-models.json
+++ b/plugins/cli-agents/references/agy-models.json
@@ -1,0 +1,125 @@
+{
+  "_meta": {
+    "source": "agy models (Antigravity CLI)",
+    "billing_model": "Google AI subscription / per-token via Antigravity",
+    "updated": "2026-06-28",
+    "notes": [
+      "agy is the sole Gemini CLI since the standalone gemini binary retired June 18 2026.",
+      "Thinking level (Low/Medium/High) is part of the model identity in agy — see display_name.",
+      "List price alone is misleading: Gemini 3.5 Flash's Thought Preservation feature carries reasoning context forward across turns, inflating real-world token spend 3-5x vs 3.1 Pro.",
+      "Gemini 3.1 Flash-Lite not available in agy as of 2026-06-28 — cheapest available model is Gemini 3.1 Pro (Low).",
+      "Model IDs for --model flag: use display_name exactly (e.g. 'Gemini 3.1 Pro (Low)') or kebab shortform where documented."
+    ]
+  },
+  "models": [
+    {
+      "display_name": "Gemini 3.1 Pro (Low)",
+      "cli_id": "gemini-3.1-pro",
+      "thinking_level": "low",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
+      "avg_turns_per_agentic_task": 26,
+      "avg_context_per_task_k": 650,
+      "recommendation": "Default — cheapest real-world agentic cost",
+      "notes": "Low thinking strips excessive reasoning loops. Best cost/quality ratio for CLI dispatch tasks."
+    },
+    {
+      "display_name": "Gemini 3.1 Pro (High)",
+      "cli_id": "gemini-3.1-pro-high",
+      "thinking_level": "high",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 2.00, "output": 12.00 },
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "Use for complex multi-step reasoning tasks",
+      "notes": "Same list price as Low; more expensive in practice due to higher token throughput per turn."
+    },
+    {
+      "display_name": "Gemini 3.5 Flash (Low)",
+      "cli_id": "gemini-3.5-flash-low",
+      "thinking_level": "low",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
+      "avg_turns_per_agentic_task": 39,
+      "avg_context_per_task_k": 1400,
+      "recommendation": "Avoid for CLI dispatch loops",
+      "notes": "Lower list price but Thought Preservation still inflates tokens even at Low. 3-5x more expensive than 3.1 Pro in practice."
+    },
+    {
+      "display_name": "Gemini 3.5 Flash (Medium)",
+      "cli_id": "gemini-3.5-flash",
+      "thinking_level": "medium",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "Legacy default — do not use",
+      "notes": "Previous cheapest_models.json default. Replaced by gemini-3.1-pro. Avoid: token burn from agentic loops."
+    },
+    {
+      "display_name": "Gemini 3.5 Flash (High)",
+      "cli_id": "gemini-3.5-flash-high",
+      "thinking_level": "high",
+      "status": "available",
+      "pricing_usd_per_1m": { "input": 1.50, "output": 9.00 },
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "Do not use",
+      "notes": "Maximum token inflation. Only viable for single-shot reasoning tasks, not CLI loops."
+    },
+    {
+      "display_name": "Claude Sonnet 4.6 (Thinking)",
+      "cli_id": "claude-sonnet-4.6-thinking",
+      "thinking_level": "thinking",
+      "status": "available",
+      "pricing_usd_per_1m": null,
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "High-value tasks requiring Anthropic quality via agy",
+      "notes": "Premium tier. Use claude-cli-agent for direct Claude access if available."
+    },
+    {
+      "display_name": "Claude Opus 4.6 (Thinking)",
+      "cli_id": "claude-opus-4.6-thinking",
+      "thinking_level": "thinking",
+      "status": "available",
+      "pricing_usd_per_1m": null,
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "Critical tasks only",
+      "notes": "Highest tier available in agy. Very expensive."
+    },
+    {
+      "display_name": "GPT-OSS 120B (Medium)",
+      "cli_id": "gpt-oss-120b",
+      "thinking_level": "medium",
+      "status": "available",
+      "pricing_usd_per_1m": null,
+      "avg_turns_per_agentic_task": null,
+      "avg_context_per_task_k": null,
+      "recommendation": "OpenAI OSS tasks via agy",
+      "notes": "Large OpenAI OSS model. Use copilot-cli-agent for direct Copilot access."
+    }
+  ],
+  "cost_tiers": {
+    "cheapest": ["gemini-3.1-pro"],
+    "moderate": ["gemini-3.1-pro-high", "gemini-3.5-flash-low"],
+    "expensive": ["gemini-3.5-flash", "gemini-3.5-flash-high"],
+    "premium": ["claude-sonnet-4.6-thinking", "claude-opus-4.6-thinking", "gpt-oss-120b"]
+  },
+  "strategy": {
+    "heartbeat": "gemini-3.1-pro",
+    "default": "gemini-3.1-pro",
+    "complex": "gemini-3.1-pro-high",
+    "anthropic_quality": "claude-sonnet-4.6-thinking"
+  },
+  "agentic_token_trap": {
+    "description": "Gemini 3.5 Flash's Thought Preservation feature carries reasoning context forward across turns by design. This causes hyper-inflation of input tokens during multi-step CLI operations even when effort is set to Low.",
+    "data": {
+      "gemini_3_5_flash": { "avg_turns": 39, "avg_context_k": 1400, "relative_cost": "3-5x" },
+      "gemini_3_1_pro_low": { "avg_turns": 26, "avg_context_k": 650, "relative_cost": "1x" }
+    },
+    "why_list_price_misleads": "Flash ($1.50/M) appears cheaper than Pro ($2.00/M) on list. In agentic CLI loops, Flash's token inflation makes it 3-5x more expensive per completed task.",
+    "recommendation": "Always use gemini-3.1-pro for CLI dispatch. Reserve Flash models for single-shot or interactive use only."
+  }
+}

--- a/plugins/cli-agents/references/backend-capabilities.md
+++ b/plugins/cli-agents/references/backend-capabilities.md
@@ -8,7 +8,7 @@ Agent MUST select backend based on task type. Do NOT use the default blindly.
 |---|---|---|---|---|
 | `claude` | `claude` | Highest reasoning, best instruction following | Cost, interactive-only without `--yolo` | Complex analysis, nuanced content, open-ended reasoning |
 | `copilot` | `copilot` | Multi-model selection, code-focused, IDE-native | Dynamic prompt injection kills KV cache; AI Credits cost | Code review, multi-file generation, structured output |
-| `agy` | `agy` | Frontier Gemini (3.5 Flash+), large context | Rate limits, `--dangerously-skip-permissions` required for headless | Long context tasks, frontier Gemini models |
+| `agy` | `agy` | All Gemini models (sole CLI since gemini binary retired June 2026); large context | Rate limits, `--dangerously-skip-permissions` required for headless; 3.5 Flash inflates tokens 3-5× | Long context tasks, all Gemini models — default to gemini-3.1-pro |
 | `codex` | `codex` | Code transformation, OpenAI models | Weaker language reasoning than Claude | Code-only tasks, diff generation, code analysis |
 | `llama` | `llama-server` (HTTP) | Fastest (~2s), zero API cost, private | Weaker reasoning than cloud models | Bounded loops, high-frequency local tasks, private data |
 | `gemini` | `gemini` | Older Gemini models, no AI Credits | Deprecated for frontier work — use `agy` | Cost-efficient older Gemini only (2.5-pro, 3-flash-preview) |

--- a/plugins/cli-agents/references/cheapest_models.json
+++ b/plugins/cli-agents/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
-    "model": "gemini-3.1-pro",
+    "model": "gemini-3.5-flash",
     "cost": "Paid (Per-token)",
-    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
+    "description": "Flash: faster, cheaper/token, optimized for agentic/tool-use tasks. Use Low thinking level."
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/cli-agents/references/cheapest_models.json
+++ b/plugins/cli-agents/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
-    "model": "gemini-3.5-flash",
-    "cost": "Paid (Per-token / Pro quotas)",
-    "description": "Antigravity CLI (replaces old gemini CLI)"
+    "model": "gemini-3.1-pro",
+    "cost": "Paid (Per-token)",
+    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/cli-agents/references/cheapest_models.json
+++ b/plugins/cli-agents/references/cheapest_models.json
@@ -5,9 +5,9 @@
     "description": "Local inference on port 8089"
   },
   "copilot": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-nano",
     "cost": "Paid (AI Credits)",
-    "description": "Standard low-cost reasoning tier"
+    "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
     "model": "gemini-3.5-flash",
@@ -15,9 +15,9 @@
     "description": "Antigravity CLI (replaces old gemini CLI)"
   },
   "claude": {
-    "model": "claude-haiku-4-5",
+    "model": "claude-haiku-4.5",
     "cost": "Paid (Per-token)",
-    "description": "High context window ($1/$5 per MTok)"
+    "description": "Cheapest Anthropic model ($1/$5 per MTok input/output)"
   },
   "codex": {
     "model": "gpt-5-mini",

--- a/plugins/cli-agents/scripts/run_agent.py
+++ b/plugins/cli-agents/scripts/run_agent.py
@@ -36,7 +36,7 @@ Flags (named-flag mode):
                     copilot → gpt-5-mini
                     gemini  → gemini-3-flash-preview
                     claude  → haiku-4.5
-                    agy     → (agy selects its own)
+                    agy     → gemini-3.5-flash (loaded from cheapest_models.json)
                     codex   → gpt-5-codex
                     llama   → gemma-4-12b
     --max-tokens  Max output tokens for cli=llama (default: 120).
@@ -71,7 +71,7 @@ def _load_default_models() -> dict[str, str | None]:
         "copilot": "gpt-5-mini",
         "gemini": "gemini-3-flash-preview",
         "claude": "haiku-4.5",
-        "agy": "gemini-3.1-pro",
+        "agy": "gemini-3.5-flash",
         "codex": "gpt-5-mini",
         "llama": "gemma-4-12b",
     }

--- a/plugins/cli-agents/scripts/run_agent.py
+++ b/plugins/cli-agents/scripts/run_agent.py
@@ -71,7 +71,7 @@ def _load_default_models() -> dict[str, str | None]:
         "copilot": "gpt-5-mini",
         "gemini": "gemini-3-flash-preview",
         "claude": "haiku-4.5",
-        "agy": "gemini-3.5-flash",
+        "agy": "gemini-3.1-pro",
         "codex": "gpt-5-mini",
         "llama": "gemma-4-12b",
     }

--- a/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
+++ b/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
@@ -30,31 +30,38 @@ You dispatch tasks to Google Gemini (and other) models via the `agy` binary.
 > `agy` is the **sole Gemini CLI** since the standalone `gemini` binary retired June 18 2026.
 > All Gemini model work — including cost-efficient older models — routes through `agy`.
 
-### Model Strategy: Use `gemini-3.1-pro` by Default
+### Model Strategy: Flash by Default, Pro for Deep Reasoning
 
 > **See `references/agy-models.json`** for the full model catalog, cost tiers, and strategy field.
 
 ```bash
-# Default (cheapest real-world agentic cost)
+# Default (Flash — faster, cheaper/token, optimized for agentic/coding tasks)
 python ./scripts/run_agent.py <PERSONA> <INPUT> <OUTPUT> "<INSTR>" --cli agy
-# ↑ run_agent.py loads gemini-3.1-pro from references/cheapest_models.json
+# ↑ run_agent.py loads gemini-3.5-flash from references/cheapest_models.json
 
-# Explicit model override
+# Explicit Low thinking (recommended for CLI loops to control Thought Preservation cost)
+python ./scripts/run_agent.py <PERSONA> <INPUT> <OUTPUT> "<INSTR>" --cli agy --model "Gemini 3.5 Flash (Low)"
+
+# Pro — escalate for deep reasoning / architecture decisions
 python ./scripts/run_agent.py <PERSONA> <INPUT> <OUTPUT> "<INSTR>" --cli agy --model gemini-3.1-pro
 ```
 
-### Agentic Token Trap — Why Flash Costs 3–5× More
+### Flash vs Pro: Which to Use
 
-Gemini 3.5 Flash has a "Thought Preservation" feature that carries reasoning context forward
-across turns. In multi-step CLI operations this **hyper-inflates input tokens** even at Low thinking:
+| | **Gemini 3.5 Flash** | **Gemini 3.1 Pro** |
+|:---|:---:|:---:|
+| Price (in/out per 1M) | $1.50 / $9.00 | $2.00 / $12.00 |
+| Speed | **4× faster** | Baseline |
+| Agentic tool use / MCP / terminal | **Best** | Good |
+| Coding (edit-test loops) | **Best** | Better for final review |
+| Deep abstract reasoning | Good | **Best** |
+| Architecture planning | Good | **Best** |
+| Max output tokens | **65,536** | 32,768 |
 
-| Model | List Price (in/out per 1M) | Avg Turns/Task | Avg Context/Task | Real Cost |
-|:---|:---:|:---:|:---:|:---:|
-| **Gemini 3.1 Pro (Low)** | $2.00 / $12.00 | ~26 | ~650K tokens | **1× (baseline)** |
-| Gemini 3.5 Flash (Low) | $1.50 / $9.00 | ~39 | ~1.4M tokens | **3–5× more expensive** |
+**Default: Flash.** Use Pro only when the task requires deep multi-step reasoning or expert-level judgment.
 
-**Bottom line:** Flash looks cheaper on list price but is far more expensive per completed task.
-Use `gemini-3.1-pro` for all CLI dispatch. Reserve Flash for single-shot or interactive sessions.
+> **Thinking level note:** Flash with High thinking can inflate tokens via Thought Preservation.
+> Use Low thinking level for high-frequency CLI dispatch loops.
 
 ---
 
@@ -102,11 +109,11 @@ python ./scripts/run_agent.py agents/security-auditor.md target.py security.md \
 
 | Display Name (agy models) | `--model` ID | Thinking | Rec |
 |:---|:---|:---:|:---|
-| **Gemini 3.1 Pro (Low)** | `gemini-3.1-pro` | Low | **Default — cheapest overall** |
-| Gemini 3.1 Pro (High) | `gemini-3.1-pro-high` | High | Complex reasoning tasks |
-| Gemini 3.5 Flash (Low) | `gemini-3.5-flash-low` | Low | Avoid in CLI loops |
-| Gemini 3.5 Flash (Medium) | `gemini-3.5-flash` | Medium | Avoid — legacy default |
-| Gemini 3.5 Flash (High) | `gemini-3.5-flash-high` | High | Avoid — max token burn |
+| **Gemini 3.5 Flash (Low)** | `gemini-3.5-flash-low` | Low | **Best for CLI loops — cheapest, fastest** |
+| Gemini 3.5 Flash (Medium) | `gemini-3.5-flash` | Medium | **Default** — standard dispatch |
+| Gemini 3.5 Flash (High) | `gemini-3.5-flash-high` | High | Single-shot deep tasks only |
+| Gemini 3.1 Pro (Low) | `gemini-3.1-pro` | Low | Deep reasoning, architecture |
+| Gemini 3.1 Pro (High) | `gemini-3.1-pro-high` | High | Most demanding reasoning only |
 | Claude Sonnet 4.6 (Thinking) | `claude-sonnet-4.6-thinking` | — | Anthropic quality via agy |
 | Claude Opus 4.6 (Thinking) | `claude-opus-4.6-thinking` | — | Critical tasks only |
 | GPT-OSS 120B (Medium) | `gpt-oss-120b` | Medium | OpenAI OSS via agy |

--- a/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
+++ b/plugins/cli-agents/skills/agy-cli-agent/SKILL.md
@@ -2,11 +2,12 @@
 name: agy-cli-agent
 plugin: cli-agents
 description: >
-  Antigravity (`agy`) CLI sub-agent system for frontier Google Gemini models.
-  Use when dispatching tasks to Gemini 3.5 Flash and above via the `agy` binary.
-  For cheaper/older Gemini models (gemini-3-flash-preview, gemini-3.1-pro-preview),
-  use gemini-cli-agent instead. Trigger with "use agy", "dispatch to antigravity",
-  "run with agy", "use frontier gemini model", or "agy sub-agent".
+  Antigravity (`agy`) CLI sub-agent system for all Google Gemini models and cross-model
+  access (Gemini, Claude, GPT-OSS) via the agy binary. Use when dispatching tasks to
+  Gemini 3.1 Pro (cheapest real-world), Gemini 3.5 Flash, or other agy-hosted models.
+  Replaces the deprecated gemini-cli-agent (gemini binary retired June 18 2026).
+  Trigger with "use agy", "dispatch to antigravity", "run with agy", "use gemini model",
+  "agy sub-agent", or "use cheapest gemini".
 allowed-tools: Bash, Read, Write
 ---
 
@@ -21,26 +22,46 @@ allowed-tools: Bash, Read, Write
 
 ---
 
-## Identity: The Antigravity Sub-Agent Dispatcher (Frontier: Gemini 3.5 Flash+)
+## Identity: The Antigravity Sub-Agent Dispatcher
 
-You dispatch tasks to Google Gemini frontier models via the `agy` binary.
+You dispatch tasks to Google Gemini (and other) models via the `agy` binary.
 
 > [!IMPORTANT]
-> `agy` is the Antigravity CLI for **frontier models only** (Gemini 3.5 Flash and above). It is a separate binary from `gemini`. For cost-efficient older models, use `gemini-cli-agent`.
+> `agy` is the **sole Gemini CLI** since the standalone `gemini` binary retired June 18 2026.
+> All Gemini model work — including cost-efficient older models — routes through `agy`.
 
-### CLI Selection Rule
+### Model Strategy: Use `gemini-3.1-pro` by Default
 
-| Use case | CLI | Binary |
-|:---|:---|:---|
-| Frontier models (3.5 Flash+) | Antigravity | `agy` |
-| Cheaper/older models (3-flash, 2.5-pro) | Gemini CLI | `gemini` |
+> **See `references/agy-models.json`** for the full model catalog, cost tiers, and strategy field.
+
+```bash
+# Default (cheapest real-world agentic cost)
+python ./scripts/run_agent.py <PERSONA> <INPUT> <OUTPUT> "<INSTR>" --cli agy
+# ↑ run_agent.py loads gemini-3.1-pro from references/cheapest_models.json
+
+# Explicit model override
+python ./scripts/run_agent.py <PERSONA> <INPUT> <OUTPUT> "<INSTR>" --cli agy --model gemini-3.1-pro
+```
+
+### Agentic Token Trap — Why Flash Costs 3–5× More
+
+Gemini 3.5 Flash has a "Thought Preservation" feature that carries reasoning context forward
+across turns. In multi-step CLI operations this **hyper-inflates input tokens** even at Low thinking:
+
+| Model | List Price (in/out per 1M) | Avg Turns/Task | Avg Context/Task | Real Cost |
+|:---|:---:|:---:|:---:|:---:|
+| **Gemini 3.1 Pro (Low)** | $2.00 / $12.00 | ~26 | ~650K tokens | **1× (baseline)** |
+| Gemini 3.5 Flash (Low) | $1.50 / $9.00 | ~39 | ~1.4M tokens | **3–5× more expensive** |
+
+**Bottom line:** Flash looks cheaper on list price but is far more expensive per completed task.
+Use `gemini-3.1-pro` for all CLI dispatch. Reserve Flash for single-shot or interactive sessions.
 
 ---
 
 ## Minimal Working Pattern
 
 ```bash
-agy --dangerously-skip-permissions -p "$(cat agents/persona.md)
+agy --dangerously-skip-permissions --model "Gemini 3.1 Pro (Low)" -p "$(cat agents/persona.md)
 
 ---SOURCE CODE---
 $(cat target.py)
@@ -59,7 +80,7 @@ Do NOT use tools. Do NOT access filesystem." > review.md
 python ./scripts/run_agent.py <PERSONA_FILE> <INPUT_FILE> <OUTPUT_FILE> "<INSTRUCTION>" --cli agy
 ```
 
-`run_agent.py` calls `agy --dangerously-skip-permissions -p` and streams output live to stdout and the output file simultaneously.
+`run_agent.py` calls `agy --dangerously-skip-permissions -p` and streams output live to stdout and the output file simultaneously. Loads model from `references/cheapest_models.json` (currently `gemini-3.1-pro`).
 
 ### Health Check
 ```bash
@@ -74,6 +95,23 @@ grep -q "HEARTBEAT_OK" ./heartbeat.md && echo "OK" || echo "FAIL"
 python ./scripts/run_agent.py agents/security-auditor.md target.py security.md \
 "Find vulnerabilities. Use severity levels: 🔴 CRITICAL, 🟡 MODERATE, 🟢 MINOR." --cli agy
 ```
+
+---
+
+## Available Models
+
+| Display Name (agy models) | `--model` ID | Thinking | Rec |
+|:---|:---|:---:|:---|
+| **Gemini 3.1 Pro (Low)** | `gemini-3.1-pro` | Low | **Default — cheapest overall** |
+| Gemini 3.1 Pro (High) | `gemini-3.1-pro-high` | High | Complex reasoning tasks |
+| Gemini 3.5 Flash (Low) | `gemini-3.5-flash-low` | Low | Avoid in CLI loops |
+| Gemini 3.5 Flash (Medium) | `gemini-3.5-flash` | Medium | Avoid — legacy default |
+| Gemini 3.5 Flash (High) | `gemini-3.5-flash-high` | High | Avoid — max token burn |
+| Claude Sonnet 4.6 (Thinking) | `claude-sonnet-4.6-thinking` | — | Anthropic quality via agy |
+| Claude Opus 4.6 (Thinking) | `claude-opus-4.6-thinking` | — | Critical tasks only |
+| GPT-OSS 120B (Medium) | `gpt-oss-120b` | Medium | OpenAI OSS via agy |
+
+> Full pricing data and strategy field: `references/agy-models.json`
 
 ---
 
@@ -92,6 +130,7 @@ python ./scripts/run_agent.py agents/security-auditor.md target.py security.md \
 | Flag | Purpose |
 |:---|:---|
 | `-p "prompt"` / `--prompt "prompt"` | Pass prompt non-interactively |
+| `--model <id>` | Select model (see table above) |
 | `--dangerously-skip-permissions` | Headless mode — skip all permission prompts |
 | `--sandbox` | Run in sandboxed environment |
 

--- a/plugins/spec-kitty-plugin/references/cheapest_models.json
+++ b/plugins/spec-kitty-plugin/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
-    "model": "gemini-3.1-pro",
+    "model": "gemini-3.5-flash",
     "cost": "Paid (Per-token)",
-    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
+    "description": "Flash: faster, cheaper/token, optimized for agentic/tool-use tasks. Use Low thinking level."
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/spec-kitty-plugin/references/cheapest_models.json
+++ b/plugins/spec-kitty-plugin/references/cheapest_models.json
@@ -10,9 +10,9 @@
     "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
-    "model": "gemini-3.5-flash",
-    "cost": "Paid (Per-token / Pro quotas)",
-    "description": "Antigravity CLI (replaces old gemini CLI)"
+    "model": "gemini-3.1-pro",
+    "cost": "Paid (Per-token)",
+    "description": "Cheapest real-world agentic model (3.5 Flash burns 3-5x more tokens)"
   },
   "claude": {
     "model": "claude-haiku-4.5",

--- a/plugins/spec-kitty-plugin/references/cheapest_models.json
+++ b/plugins/spec-kitty-plugin/references/cheapest_models.json
@@ -5,9 +5,9 @@
     "description": "Local inference on port 8089"
   },
   "copilot": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-nano",
     "cost": "Paid (AI Credits)",
-    "description": "Standard low-cost reasoning tier"
+    "description": "Cheapest Copilot model: 20 cr/1M input, 125 cr/1M output"
   },
   "agy": {
     "model": "gemini-3.5-flash",
@@ -15,9 +15,9 @@
     "description": "Antigravity CLI (replaces old gemini CLI)"
   },
   "claude": {
-    "model": "claude-haiku-4-5",
+    "model": "claude-haiku-4.5",
     "cost": "Paid (Per-token)",
-    "description": "High context window ($1/$5 per MTok)"
+    "description": "Cheapest Anthropic model ($1/$5 per MTok input/output)"
   },
   "codex": {
     "model": "gpt-5-mini",


### PR DESCRIPTION
## Summary

- **Copilot billing model**: Remove incorrect "gpt-5-mini included/free" claim; document full AI Credits model (June 2026). Add `references/copilot-models.json` with 21 models, pricing, strategy field. Update `CLAUDE.md` delegation pattern to reference JSON instead of hardcoded names.
- **gpt-5.4-nano**: Replace `gpt-5-mini` as cheapest Copilot model across all 4 canonical `cheapest_models.json` files and `swarm_run.py` fallback (20 cr/1M input vs 25 cr/1M).
- **MAI-Code-1-Flash**: Document new Microsoft model (Jun 2026) — similar code quality to Claude Sonnet 4.6 at ~4× lower AI Credits cost.
- **Execution contract + backend capabilities**: Add `references/execution-contract.md` (one backend per task, mandatory validator orchestration, isolation policy) and `references/backend-capabilities.md` (full capability matrix with isolation behavior per CLI).
- **KV cache limitation**: Document in `kv_cache_orchestrator.py` that CLI tools inject dynamic context → near-zero hit rate for CLI-driven sessions.
- **conductor.py deprecation**: Mark deprecated in favor of `run_agent.py` (6 backends vs 3, 76 tests).
- **agy-cli-agent**: Full SKILL.md rewrite — remove "frontier models only" language (gemini binary retired June 2026, agy is now sole Gemini CLI). Add `references/agy-models.json` with Flash vs Pro tradeoffs (Flash: default, cheaper/token, 4× faster, optimized for agentic tasks; Pro: deep reasoning/architecture). Fix `claude-haiku-4-5` → `claude-haiku-4.5` identifier in all canonical files.

## Test plan

- [ ] Verify `cheapest_models.json` symlinks resolve correctly via `symlink_manager.py diagnose`
- [ ] Confirm `run_agent.py` loads `gpt-5.4-nano` for copilot and `gemini-3.5-flash` for agy from JSON
- [ ] Review `copilot-models.json` and `agy-models.json` for accuracy before sharing with agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)