### PR TITLE
fix(plugin-manager): skip dirs without manifest in Tier 1 discovery

### DIFF
--- a/plugins/plugin-manager/scripts/plugin_add.py
+++ b/plugins/plugin-manager/scripts/plugin_add.py
@@ -391,6 +391,8 @@ def _discover_plugins(search_root: Path) -> list:
                 continue
             if p.name in SKIP:
                 continue
+            if not _has_plugin_manifest(p):
+                continue
             plugins.append(_read_plugin_meta(p))
         return plugins
 


### PR DESCRIPTION
## Summary

- Tier 1 plugin discovery (`_scan_dir`) now applies the same `_has_plugin_manifest` guard that Tier 2 already used
- Stub/deprecated plugin directories (e.g. `spec-kitty-plugin`) are silently skipped instead of being discovered and failing validation
- Fixes the `✗ Validation Failed: Missing manifest` error seen during `uvx plugin-add`

## Test plan

- [ ] Run `uvx --from git+https://github.com/richfrem/agent-plugins-skills plugin-add richfrem/agent-plugins-skills --all -y` and confirm 10/10 success, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)