### PR TITLE
updated self-evolution policy

### DIFF
--- a/.agent/rules/self-evolution-policy.md
+++ b/.agent/rules/self-evolution-policy.md
@@ -1,129 +1,36 @@
 ---
+trigger: always_on
 description: Universal rules for agent self-healing, selector repair, and error recovery policies.
 globs: ["**/*"]
 ---
 
 ## 🌀 Self-Evolution & Self-Healing Policy
 
-**Full execution protocol (Phases 0–7) → `plugins/agent-agentic-os/skills/self-evolution/SKILL.md`**  
-**Skill/directory deletion rules → `.agent/rules/skill-deletion-guard.md`**
+**Full context and execution loop → `plugins/agent-agentic-os/skills/self-evolution/SKILL.md`**
 
-This policy states the always-on safety gates. They apply before any skill is invoked and
-regardless of whether a self-evolution run is in progress.
+This policy governs how agents must respond when a tool call, subprocess, web automation step, or selector query encounters a failure. Rather than just retrying or patching silently, the agent must treat failures as evolution events.
 
-### Hard Gates (always active)
+### Non-Negotiables
 
-1. **Edit boundaries first**: Before any autonomous edit, verify the target file is inside
-   the plugin's permitted edit directories (`plugins/<plugin>/skills/`, `scripts/`, `references/`).
-   If no `self-evolution-profile.md` exists for the plugin, use that conservative default.
-   Anything outside those dirs requires explicit user confirmation.
+1. **Verify Edit Boundaries First**: Before making any autonomous edits to repair a failure, check the permitted edit boundaries in `<plugin>/references/self-evolution-profile.md`. If a repair requires modifying code outside these directories, **escalate to the user immediately**—do not ask for forgiveness.
+2. **Classify Failures by Tier**: Group all failures into exactly one tier to determine the required action:
+   * **Tier 1 (Gap)**: Capability doesn't exist yet (build missing piece, no evidence needed).
+   * **Tier 2 (Failure)**: Code exists but is broken or returns errors (patch minimal code, save stack traces).
+   * **Tier 3 (Regression)**: External change broke previously working behavior, e.g., stale DOM selectors or API mutations (collect DOM/network/screenshot evidence first, then patch with primary + fallback selector paths).
+3. **Three-Attempt Maximum**: Do not loop or retry a failing repair silently. Attempt to fix a problem up to **three times**. If the third attempt fails, **hard stop** and present the formal Escalation Template to the user with the evidence bundle.
+4. **Update The Map, Not Just the Diary**: A fix that is not recorded is a future regression waiting to happen. You must:
+   * Update the relevant domain playbooks and references (`references/<topic>-playbook.md`) with updated selectors or timing rules.
+   * Log the evolution step in `evolution-log.md` with the exact tier, target, and outcome.
+5. **Autonomy & Permission Gates**:
+   * **Auto-approved**: Adding new functions/exports, fallback selectors, and appending diffs for modified functions.
+   * **Explicit Confirmation Gated**: Renaming or moving files.
+   * **Hard Gated**: **Deletions of any file or function are strictly forbidden** without explicit human permission.
+6. **One Logical Fix at a Time**: Apply one clean fix per execution pass. Never bundle multiple refactoring changes or unrelated patches together.
 
-2. **Three-attempt maximum**: Attempt a repair up to three times. On the third failure,
-   hard stop and present the Escalation Template with the full evidence bundle.
+7. **Fix Forward, Never Skip**: When a tool, script, or automation step fails, fix it at the source immediately and update the relevant playbook. Do NOT work around failures, add retries without understanding the root cause, or leave the fix for later. Every session must end with the same capabilities working as reliably as they started. The goal is smooth, issue-free runs in every future session — compound the fixes, not the workarounds.
 
-3. **Update The Map, not just the Diary**: Every fix must update the relevant domain playbook
-   or reference file. A fix that is not recorded is a future regression.
+8. **Synchronize Sweep Templates on Thesis/Strategy Changes**: Whenever the core investment thesis, sub-strategies, or target weights are modified:
+   * You MUST update the "Core Portfolio Thesis Background" section inside both the daily sweep template (`plugins/portfolio-advisor/assets/templates/daily_sweep.md.template`) and the weekly sweep template (`plugins/portfolio-advisor/assets/templates/weekly_sweep.md.template`).
+   * Regenerate the final prompt outputs to verify they align with the updated strategies.
 
-4. **Autonomy gates**:
-   - Auto-approved: adding new functions/exports, fallback selectors, appending to existing files
-   - Explicit confirmation required: renaming or moving any file
-   - **Hard gated — always requires explicit human permission**: any deletion of any file,
-     function, skill, SKILL.md, eval, or reference. See `skill-deletion-guard.md`.
-
-5. **The Absorption Fallacy — always wrong**: Concluding that a skill, file, or directory is
-   "redundant", "absorbed", "consolidated", or "superseded" and deleting it autonomously.
-   Overlap is never evidence that deletion is safe. Flag it; never act on it.
-
-6. **One logical change per pass**: Never bundle multiple independent repairs in a single
-   execution pass.
-
----
-
-### Friction-Driven Self-Evolution (always active)
-
-Agents must not silently work around broken, unclear, missing, or awkward repo capabilities.
-
-A self-evolution event is required when **any** of the following occurs:
-
-- A script, helper, command, skill, sub-agent, selector, eval, or documented workflow fails.
-- The agent avoids an existing capability and performs the work manually instead.
-- The agent uses a workaround because the intended path was broken, unclear, or ambiguous.
-- The agent has to guess because instructions, profiles, schemas, or routing are unclear.
-- The user corrects the agent on a repeatable process problem.
-- The agent notices a missing helper, stale reference, stale agent instruction, or broken skill invocation.
-
-**Successful task completion does not waive this requirement.** If the task succeeded only
-because the agent bypassed friction, self-evolution handling is still required.
-
----
-
-### Tier 0 — Friction / Workaround
-
-> "The task completed, but the system did not improve."
-
-**Signals:**
-- Agent bypassed an existing script, skill, sub-agent, or helper
-- Agent manually performed work that an existing repo capability should handle
-- Agent encountered ambiguity and guessed instead of improving instructions
-- Agent noticed an awkward or error-prone workflow but did not update The Map
-- Agent used a temporary workaround
-
-**Required response — pick exactly one:**
-- Fix is small + inside allowed edit boundaries → patch it now, update The Map.
-- Fix is not safe or not small → record **Map Debt** in `<plugin>/references/map-debt.md` and append an audit row to the evolution log.
-- Friction is repeated or blocking → escalate to the user.
-
----
-
-### No Silent Bypass Rule
-
-If an existing repo capability is intended for the task, the agent must use it.
-If the capability fails, the agent may use a workaround only after recording the failure
-as a self-evolution event. Silent bypass is a protocol violation.
-
----
-
-### Pre-Completion Self-Evolution Gate
-
-Before claiming a task is complete, output this block verbatim:
-
-```
-PRE-COMPLETION GATE:
-  Capability check: Did I verify whether an existing repo capability was intended for this task? [YES/NO]
-  1. Did any existing capability fail, get bypassed, or get manually replaced?  [YES/NO — 1 line if YES]
-  2. Did I guess, assume, or get corrected on a repeatable process?              [YES/NO — 1 line if YES]
-  3. Did I notice something the next agent will hit again if not fixed?          [YES/NO — 1 line if YES]
-
-If any YES: action taken → FIX / MAP_DEBT / ESCALATE
-```
-
-The block must be emitted as literal text, not silent introspection. The task is not complete
-until every YES has a declared action.
-
----
-
-### Map Debt
-
-If friction is real but cannot be fixed immediately, record it as Map Debt.
-
-Map Debt lives in `<plugin>/references/map-debt.md` — a working queue separate from the
-evolution log. The evolution log is append-only audit history. Map Debt is mutable: entries
-are resolved, aged, or escalated over time. Do not conflate the two.
-
-Each Map Debt entry must include:
-- Logged date (`YYYY-MM-DD`)
-- Cycle ID (from `events.jsonl`)
-- Artifact affected (file path or skill slug)
-- Friction observed (one sentence)
-- Why it was not fixed now
-- Recommended fix
-- Evidence or reproduction step
-- Severity: S / M / L
-- Repeat: YES / NO
-- Status: OPEN / RESOLVED / ESCALATED
-
-**Aging rule:** At Phase 0 read, count completed cycles since entry's Cycle ID. If an `OPEN`
-entry is older than 3 completed cycles, auto-escalate before starting new work.
-If the entry's Cycle ID is from a prior session (not in current `events.jsonl`), fall back
-to the Logged date: auto-escalate if `(today - Logged) > 14 days`.
-**Repeat = YES:** must escalate on next encounter — no further deferral permitted.
+9. **Refine Prompt Templates on Ingesting Grok Responses**: Every time you ingest and process a Grok sweep response, you MUST evaluate its quality (checking for grouped tickers, lazy placeholders, or TA-related errors) and immediately update the prompt templates (`daily_sweep.md.template` and `weekly_sweep.md.template`) to guard against any observed deficiencies.

--- a/agent-rules-to-add-when-needed/self-evolution-policy.md
+++ b/agent-rules-to-add-when-needed/self-evolution-policy.md
@@ -5,125 +5,31 @@ globs: ["**/*"]
 
 ## 🌀 Self-Evolution & Self-Healing Policy
 
-**Full execution protocol (Phases 0–7) → `plugins/agent-agentic-os/skills/self-evolution/SKILL.md`**  
-**Skill/directory deletion rules → `.agent/rules/skill-deletion-guard.md`**
+**Full context and execution loop → `plugins/agent-agentic-os/skills/self-evolution/SKILL.md`**
 
-This policy states the always-on safety gates. They apply before any skill is invoked and
-regardless of whether a self-evolution run is in progress.
+This policy governs how agents must respond when a tool call, subprocess, web automation step, or selector query encounters a failure. Rather than just retrying or patching silently, the agent must treat failures as evolution events.
 
-### Hard Gates (always active)
+### Non-Negotiables
 
-1. **Edit boundaries first**: Before any autonomous edit, verify the target file is inside
-   the plugin's permitted edit directories (`plugins/<plugin>/skills/`, `scripts/`, `references/`).
-   If no `self-evolution-profile.md` exists for the plugin, use that conservative default.
-   Anything outside those dirs requires explicit user confirmation.
+1. **Verify Edit Boundaries First**: Before making any autonomous edits to repair a failure, check the permitted edit boundaries in `<plugin>/references/self-evolution-profile.md`. If a repair requires modifying code outside these directories, **escalate to the user immediately**—do not ask for forgiveness.
+2. **Classify Failures by Tier**: Group all failures into exactly one tier to determine the required action:
+   * **Tier 1 (Gap)**: Capability doesn't exist yet (build missing piece, no evidence needed).
+   * **Tier 2 (Failure)**: Code exists but is broken or returns errors (patch minimal code, save stack traces).
+   * **Tier 3 (Regression)**: External change broke previously working behavior, e.g., stale DOM selectors or API mutations (collect DOM/network/screenshot evidence first, then patch with primary + fallback selector paths).
+3. **Three-Attempt Maximum**: Do not loop or retry a failing repair silently. Attempt to fix a problem up to **three times**. If the third attempt fails, **hard stop** and present the formal Escalation Template to the user with the evidence bundle.
+4. **Update The Map, Not Just the Diary**: A fix that is not recorded is a future regression waiting to happen. You must:
+   * Update the relevant domain playbooks and references (`references/<topic>-playbook.md`) with updated selectors or timing rules.
+   * Log the evolution step in `evolution-log.md` with the exact tier, target, and outcome.
+5. **Autonomy & Permission Gates**:
+   * **Auto-approved**: Adding new functions/exports, fallback selectors, and appending diffs for modified functions.
+   * **Explicit Confirmation Gated**: Renaming or moving files.
+   * **Hard Gated**: **Deletions of any file or function are strictly forbidden** without explicit human permission.
+6. **One Logical Fix at a Time**: Apply one clean fix per execution pass. Never bundle multiple refactoring changes or unrelated patches together.
 
-2. **Three-attempt maximum**: Attempt a repair up to three times. On the third failure,
-   hard stop and present the Escalation Template with the full evidence bundle.
+7. **Fix Forward, Never Skip**: When a tool, script, or automation step fails, fix it at the source immediately and update the relevant playbook. Do NOT work around failures, add retries without understanding the root cause, or leave the fix for later. Every session must end with the same capabilities working as reliably as they started. The goal is smooth, issue-free runs in every future session — compound the fixes, not the workarounds.
 
-3. **Update The Map, not just the Diary**: Every fix must update the relevant domain playbook
-   or reference file. A fix that is not recorded is a future regression.
+8. **Synchronize Sweep Templates on Thesis/Strategy Changes**: Whenever the core investment thesis, sub-strategies, or target weights are modified:
+   * You MUST update the "Core Portfolio Thesis Background" section inside both the daily sweep template (`plugins/portfolio-advisor/assets/templates/daily_sweep.md.template`) and the weekly sweep template (`plugins/portfolio-advisor/assets/templates/weekly_sweep.md.template`).
+   * Regenerate the final prompt outputs to verify they align with the updated strategies.
 
-4. **Autonomy gates**:
-   - Auto-approved: adding new functions/exports, fallback selectors, appending to existing files
-   - Explicit confirmation required: renaming or moving any file
-   - **Hard gated — always requires explicit human permission**: any deletion of any file,
-     function, skill, SKILL.md, eval, or reference. See `skill-deletion-guard.md`.
-
-5. **The Absorption Fallacy — always wrong**: Concluding that a skill, file, or directory is
-   "redundant", "absorbed", "consolidated", or "superseded" and deleting it autonomously.
-   Overlap is never evidence that deletion is safe. Flag it; never act on it.
-
-6. **One logical change per pass**: Never bundle multiple independent repairs in a single
-   execution pass.
-
----
-
-### Friction-Driven Self-Evolution (always active)
-
-Agents must not silently work around broken, unclear, missing, or awkward repo capabilities.
-
-A self-evolution event is required when **any** of the following occurs:
-
-- A script, helper, command, skill, sub-agent, selector, eval, or documented workflow fails.
-- The agent avoids an existing capability and performs the work manually instead.
-- The agent uses a workaround because the intended path was broken, unclear, or ambiguous.
-- The agent has to guess because instructions, profiles, schemas, or routing are unclear.
-- The user corrects the agent on a repeatable process problem.
-- The agent notices a missing helper, stale reference, stale agent instruction, or broken skill invocation.
-
-**Successful task completion does not waive this requirement.** If the task succeeded only
-because the agent bypassed friction, self-evolution handling is still required.
-
----
-
-### Tier 0 — Friction / Workaround
-
-> "The task completed, but the system did not improve."
-
-**Signals:**
-- Agent bypassed an existing script, skill, sub-agent, or helper
-- Agent manually performed work that an existing repo capability should handle
-- Agent encountered ambiguity and guessed instead of improving instructions
-- Agent noticed an awkward or error-prone workflow but did not update The Map
-- Agent used a temporary workaround
-
-**Required response — pick exactly one:**
-- Fix is small + inside allowed edit boundaries → patch it now, update The Map.
-- Fix is not safe or not small → record **Map Debt** in `<plugin>/references/map-debt.md` and append an audit row to the evolution log.
-- Friction is repeated or blocking → escalate to the user.
-
----
-
-### No Silent Bypass Rule
-
-If an existing repo capability is intended for the task, the agent must use it.
-If the capability fails, the agent may use a workaround only after recording the failure
-as a self-evolution event. Silent bypass is a protocol violation.
-
----
-
-### Pre-Completion Self-Evolution Gate
-
-Before claiming a task is complete, output this block verbatim:
-
-```
-PRE-COMPLETION GATE:
-  Capability check: Did I verify whether an existing repo capability was intended for this task? [YES/NO]
-  1. Did any existing capability fail, get bypassed, or get manually replaced?  [YES/NO — 1 line if YES]
-  2. Did I guess, assume, or get corrected on a repeatable process?              [YES/NO — 1 line if YES]
-  3. Did I notice something the next agent will hit again if not fixed?          [YES/NO — 1 line if YES]
-
-If any YES: action taken → FIX / MAP_DEBT / ESCALATE
-```
-
-The block must be emitted as literal text, not silent introspection. The task is not complete
-until every YES has a declared action.
-
----
-
-### Map Debt
-
-If friction is real but cannot be fixed immediately, record it as Map Debt.
-
-Map Debt lives in `<plugin>/references/map-debt.md` — a working queue separate from the
-evolution log. The evolution log is append-only audit history. Map Debt is mutable: entries
-are resolved, aged, or escalated over time. Do not conflate the two.
-
-Each Map Debt entry must include:
-- Logged date (`YYYY-MM-DD`)
-- Cycle ID (from `events.jsonl`)
-- Artifact affected (file path or skill slug)
-- Friction observed (one sentence)
-- Why it was not fixed now
-- Recommended fix
-- Evidence or reproduction step
-- Severity: S / M / L
-- Repeat: YES / NO
-- Status: OPEN / RESOLVED / ESCALATED
-
-**Aging rule:** At Phase 0 read, count completed cycles since entry's Cycle ID. If an `OPEN`
-entry is older than 3 completed cycles, auto-escalate before starting new work.
-If the entry's Cycle ID is from a prior session (not in current `events.jsonl`), fall back
-to the Logged date: auto-escalate if `(today - Logged) > 14 days`.
-**Repeat = YES:** must escalate on next encounter — no further deferral permitted.
+9. **Refine Prompt Templates on Ingesting Grok Responses**: Every time you ingest and process a Grok sweep response, you MUST evaluate its quality (checking for grouped tickers, lazy placeholders, or TA-related errors) and immediately update the prompt templates (`daily_sweep.md.template` and `weekly_sweep.md.template`) to guard against any observed deficiencies.

--- a/plugin-sources.json
+++ b/plugin-sources.json
@@ -15,6 +15,12 @@
     {
       "source": "richfrem/agent-plugins-skills",
       "plugins": [
+        "spec-kitty"
+      ]
+    },
+    {
+      "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
+      "plugins": [
         "agent-agentic-os",
         "agent-loops",
         "agent-memory",
@@ -24,8 +30,7 @@
         "dev-utils",
         "exploration-cycle-plugin",
         "obsidian-wiki-engine",
-        "plugin-manager",
-        "spec-kitty"
+        "plugin-manager"
       ]
     }
   ]

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -67,7 +67,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -88,42 +88,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "agy-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "analyze-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "antigravity-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:45.204613Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "brainstorming": {
       "source": "https://github.com/obra/superpowers",
@@ -137,56 +137,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.901366Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "business-requirements-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "business-workflow-doc": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "claude-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:44.824639Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "codex-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "compile-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -205,7 +205,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -226,70 +226,70 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "convert-plugin-to-apm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "create-agentic-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -301,35 +301,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "deferred": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -343,14 +343,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-06-29T01:56:23.241859Z"
+      "updatedAt": "2026-06-29T13:57:48.454527Z"
     },
     "discovery-planning": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "dispatching-parallel-agents": {
       "source": "https://github.com/obra/superpowers",
@@ -364,28 +364,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "eval-autoresearch-fit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:54:04.213659Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -481,14 +481,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "exploration-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
@@ -502,14 +502,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "exploration-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "finishing-a-development-branch": {
       "source": "https://github.com/obra/superpowers",
@@ -523,7 +523,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T18:32:57.701906Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -535,84 +535,84 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "gpt55-critical-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:10:59.858498Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "hf-download": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.901366Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "hf-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "install-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "local-llm-bridge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "local-llm-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "loop-progress-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -626,14 +626,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "manage-marketplace": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -647,91 +647,91 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-query-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-rlm-distiller": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-wiki-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "obsidian-wiki-linter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-06-29T01:56:23.571759Z"
+      "updatedAt": "2026-06-29T13:57:48.867143Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -745,14 +745,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T14:43:50.703180Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "optimize-context": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-11T15:20:19.257058Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "oracle-legacy-system-analysis-business-rules": {
       "source": "oracle-legacy-system-analysis",
@@ -857,35 +857,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "os-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-environment-probe": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-26T18:04:54.227742Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-eval-lab": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -899,77 +899,77 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:55:32.819746Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-evolution-planner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-evolution-verifier": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-experiment-log": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "package-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -983,28 +983,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "plugin-installer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-06-29T01:56:23.631058Z"
+      "updatedAt": "2026-06-29T13:57:48.922890Z"
     },
     "plugin-remover": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T14:53:48.497968Z",
-      "updatedAt": "2026-06-29T01:56:23.631058Z"
+      "updatedAt": "2026-06-29T13:57:48.922890Z"
     },
     "plugin-syncer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T15:51:44.964142Z",
-      "updatedAt": "2026-06-29T01:56:23.631058Z"
+      "updatedAt": "2026-06-29T13:57:48.922890Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -1016,14 +1016,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-06-29T01:56:23.192798Z"
+      "updatedAt": "2026-06-29T13:57:48.399710Z"
     },
     "prototype-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "receiving-code-review": {
       "source": "https://github.com/obra/superpowers",
@@ -1037,14 +1037,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "red-team-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1072,28 +1072,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.409753Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1107,14 +1107,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "sanctuary-memory": {
       "source": "richfrem/Project_Sanctuary",
@@ -1146,14 +1146,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "self-evolution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:48.041518Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1333,21 +1333,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-31T19:06:22.971138Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "systematic-debugging": {
       "source": "https://github.com/obra/superpowers",
@@ -1361,7 +1361,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-06-29T01:56:23.367300Z"
+      "updatedAt": "2026-06-29T13:57:48.624817Z"
     },
     "test-driven-development": {
       "source": "https://github.com/obra/superpowers",
@@ -1375,7 +1375,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-06-29T01:56:21.993434Z"
+      "updatedAt": "2026-06-29T13:57:47.260829Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1396,28 +1396,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T20:54:39.722191Z",
-      "updatedAt": "2026-06-29T01:56:22.077130Z"
+      "updatedAt": "2026-06-29T13:57:47.332103Z"
     },
     "update-ecosystem-index": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-06-29T01:56:23.089473Z"
+      "updatedAt": "2026-06-29T13:57:48.303303Z"
     },
     "user-story-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "using-exploration-cycle": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.988173Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "using-git-worktrees": {
       "source": "https://github.com/obra/superpowers",
@@ -1438,42 +1438,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-06-29T01:56:22.373637Z"
+      "updatedAt": "2026-06-29T13:57:47.557853Z"
     },
     "verification-before-completion": {
       "source": "https://github.com/obra/superpowers",
@@ -1487,21 +1487,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-browser-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-domain-extractor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1515,42 +1515,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-slice-migrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-spec-packager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-to-speckit-superpowers": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T19:13:31.238310Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "vibe-togaf-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "visual-companion": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-06-29T01:56:23.478644Z"
+      "updatedAt": "2026-06-29T13:57:48.759490Z"
     },
     "writing-plans": {
       "source": "https://github.com/obra/superpowers",


### PR DESCRIPTION
This pull request makes significant updates to the agent self-evolution policy documentation, clarifies plugin source configuration, and refreshes skill lock metadata. The most important changes are the full rewrite and consolidation of the self-evolution policy, improvements to plugin management, and routine metadata updates.

**Self-Evolution Policy Overhaul:**

* The self-evolution policy in `.agent/rules/self-evolution-policy.md` and `agent-rules-to-add-when-needed/self-evolution-policy.md` has been fully rewritten for clarity and conciseness. The new version introduces "Non-Negotiables"—a set of strict, actionable rules for agent self-healing and error recovery, including explicit boundaries for autonomous edits, a tiered failure classification system, strict escalation and logging requirements, and new mandates for updating investment strategy templates and prompt refinement. This replaces the previous, more verbose policy with a focused, actionable protocol. [[1]](diffhunk://#diff-aa800c5803e93ce7e7a24649b0a54b73ea2493668eb47c882cde3706aa28e42dR2-R36) [[2]](diffhunk://#diff-458882fea9e8b7f71904109e3a411df669d7628d952f4a9ef0dd196bde32feedL8-R35)

**Plugin Source Configuration:**

* Updates to `plugin-sources.json` clarify plugin sourcing: the `spec-kitty` plugin is now listed only under the `richfrem/agent-plugins-skills` source, and a new local path source for plugins is added. This reduces redundancy and ensures the correct plugin source mapping. [[1]](diffhunk://#diff-8cbf44b5f3bb8a19bde67d57cb8975503881d27437af0d864ea7f2f292f72cb3R17-R22) [[2]](diffhunk://#diff-8cbf44b5f3bb8a19bde67d57cb8975503881d27437af0d864ea7f2f292f72cb3L27-R33)

**Skill Lock Metadata Refresh:**

* The `skills-lock.json` file has updated `updatedAt` timestamps for several plugins, reflecting the latest install or update times. There are no changes to plugin content or logic—these are routine metadata updates. [[1]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL14-R14) [[2]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL70-R70) [[3]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL91-R126) [[4]](diffhunk://#diff-24f818c99965183008b728f1585e20a3923e08ebd68dc577245b10d01752499fL140-R189)