### PR TITLE
refactor: break up functions exceeding 50 lines in plugin-manager

### DIFF
--- a/plugins/agent-scaffolders/scripts/fix_plugin_load_errors.py
+++ b/plugins/agent-scaffolders/scripts/fix_plugin_load_errors.py
@@ -28,6 +28,16 @@ NOTE: Claude Code scans ALL cached plugin versions under ~/.claude/plugins/cache
 Usage:
     python fix_plugin_load_errors.py <plugin_root>
     python fix_plugin_load_errors.py .
+
+Key Input Dependencies:
+    - Plugin root directory with plugin.json, hooks.json, SKILL.md files
+    - Write permissions to modify plugin configuration files
+
+Key Functions:
+    - fix_plugin_json(): Remove banned fields from plugin.json
+    - fix_hooks_json(): Fix malformed hooks.json structures
+    - fix_skill_md(): Remove comments before SKILL.md frontmatter
+    - scan_and_fix(): Recursively scan and fix all plugins
 """
 import sys
 import json
@@ -50,6 +60,7 @@ def fix_literal_newlines(content: str) -> tuple[str, bool]:
 
 
 def fix_plugin_json(path: Path) -> list[str]:
+    """Remove banned fields from plugin.json that Claude Code validator rejects."""
     fixes = []
     try:
         text = path.read_text(encoding="utf-8")
@@ -70,6 +81,7 @@ def fix_plugin_json(path: Path) -> list[str]:
 
 
 def fix_hooks_json(path: Path) -> list[str]:
+    """Fix malformed hooks.json structures (literal newlines, array format, missing wrapper)."""
     fixes = []
     try:
         raw = path.read_text(encoding="utf-8")
@@ -169,6 +181,7 @@ def fix_skill_md(path: Path) -> list[str]:
 
 
 def scan_and_fix(plugin_root: Path) -> int:
+    """Scan plugin directory and apply all applicable fixes, return count of fixes."""
     all_fixes = []
 
     # 1. plugin.json
@@ -213,6 +226,7 @@ def scan_and_fix(plugin_root: Path) -> int:
 
 
 def main() -> None:
+    """Parse CLI argument and execute plugin load error fixes."""
     plugin_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
 
     if not plugin_root.is_dir():

--- a/plugins/agent-scaffolders/scripts/gh_agent_templates.py
+++ b/plugins/agent-scaffolders/scripts/gh_agent_templates.py
@@ -5,6 +5,17 @@ gh_agent_templates.py
 Purpose:
     Pure template functions for generating GitHub AI Agent configurations.
     Contains no I/O, making it fully unit-testable.
+
+Layer: Codify
+
+Key Input Dependencies:
+    - YAML configuration data (agent metadata, tools, models, MCP servers)
+    - GitHub AI Agent specification format
+
+Key Functions:
+    - agent_md_github(): Generate Target A Custom Copilot Agent frontmatter
+    - gh_aw_workflow_md(): Generate GitHub Actions Workflow template
+    - runner_yml(): Generate GitHub Actions runner configuration
 """
 
 import re

--- a/plugins/plugin-manager/scripts/plugin_add.py
+++ b/plugins/plugin-manager/scripts/plugin_add.py
@@ -155,6 +155,88 @@ def _clear_lines(n: int) -> None:
 # ---------------------------------------------------------------------------
 # Interactive multi-select (space = toggle, enter = confirm, / = search)
 # ---------------------------------------------------------------------------
+def _multiselect_filtered(items: list, search: str) -> list:
+    """Filter items by current search query (case-insensitive name/description match)."""
+    q = search.lower()
+    return [i for i in items if q in i["name"].lower() or q in i.get("description", "").lower()]
+
+
+def _multiselect_render(title: str, items: list, filtered: list, selected: set,
+                         cursor: int, search: str, first_render: bool = False) -> int:
+    """Render the TUI menu and return the number of printed lines."""
+    PAGE = 18                   # visible rows
+    lines = []
+    lines.append(bold(title))
+    lines.append(dim("  ↑↓ move  |  space select  |  / search  |  a all  |  enter confirm  |  q quit"))
+    if search:
+        lines.append(f"  {dim('Search:')} {cyan(search)}_")
+    else:
+        lines.append(dim("  Type / to search"))
+
+    visible = filtered[max(0, cursor - PAGE // 2): cursor + PAGE]
+    offset = max(0, cursor - PAGE // 2)
+
+    for idx, item in enumerate(visible):
+        is_cursor = (offset + idx) == cursor
+        is_selected = item["name"] in selected
+        check = green("[x]") if is_selected else dim("[ ]")
+        name  = cyan(item["name"]) if is_cursor else item["name"]
+        desc  = dim(item.get("description", "")[:55])
+        arrow = ">" if is_cursor else " "
+        lines.append(f"  {arrow} {check} {name}  {desc}")
+
+    count = len(selected)
+    total = len(filtered)
+    lines.append("")
+    lines.append(f"  {green(str(count))} of {total} selected")
+
+    if not first_render:
+        _clear_lines(len(lines))
+    print("\n".join(lines), flush=True)
+    return len(lines)
+
+
+def _multiselect_process_key(key: str, cursor: int, selected: set, search: str,
+                              items: list) -> tuple[int, set, str, bool]:
+    """Handle one keypress and return updated (cursor, selected, search, should_break).
+
+    Args:
+        key: Keypress token from _read_key().
+        cursor: Current cursor row index in the filtered list.
+        selected: Set of currently selected item names.
+        search: Current search query string.
+        items: Full unfiltered item list (used for filtering and 'a' toggle-all).
+
+    Returns:
+        Updated (cursor, selected, search, should_break).
+    """
+    f = _multiselect_filtered(items, search)
+    n = len(f)
+    if key == "UP":
+        cursor = max(0, cursor - 1)
+    elif key == "DOWN":
+        cursor = min(n - 1, cursor + 1)
+    elif key == " ":
+        if f and 0 <= cursor < n:
+            name = f[cursor]["name"]
+            selected.discard(name) if name in selected else selected.add(name)
+    elif key in ("\r", "\n", ""):
+        return cursor, selected, search, True
+    elif key in ("q", "Q", "\x03"):
+        print(red("\nCancelled."))
+        sys.exit(0)
+    elif key == "a":
+        selected = set() if len(selected) == len(items) else {i["name"] for i in items}
+    elif key == "/":
+        search, cursor = "", 0
+    elif key == "\x7f":
+        search, cursor = search[:-1], 0
+    elif key and len(key) == 1 and key.isprintable():
+        search += key
+        cursor = 0
+    return cursor, selected, search, False
+
+
 def _multiselect(title: str, items: list) -> list:
     """Interactive arrow-key multi-select TUI for choosing plugins.
 
@@ -174,95 +256,18 @@ def _multiselect(title: str, items: list) -> list:
     selected = set()
     cursor = 0
     search = ""
-    PAGE = 18                   # visible rows
 
-    def _filtered() -> list:
-        """Filter items by current search query (case-insensitive name/description match)."""
-        q = search.lower()
-        return [i for i in items if q in i["name"].lower() or q in i.get("description", "").lower()]
-
-    def _render(filtered: list, first_render: bool = False) -> int:
-        """Render the TUI menu and return the number of printed lines."""
-        lines = []
-        lines.append(bold(title))
-        lines.append(dim("  ↑↓ move  |  space select  |  / search  |  a all  |  enter confirm  |  q quit"))
-        if search:
-            lines.append(f"  {dim('Search:')} {cyan(search)}_")
-        else:
-            lines.append(dim("  Type / to search"))
-
-        visible = filtered[max(0, cursor - PAGE // 2): cursor + PAGE]
-        offset = max(0, cursor - PAGE // 2)
-
-        for idx, item in enumerate(visible):
-            real_idx = items.index(item)
-            is_cursor = (offset + idx) == cursor
-            is_selected = item["name"] in selected
-            check = green("[x]") if is_selected else dim("[ ]")
-            name  = cyan(item["name"]) if is_cursor else item["name"]
-            desc  = dim(item.get("description", "")[:55])
-            arrow = ">" if is_cursor else " "
-            lines.append(f"  {arrow} {check} {name}  {desc}")
-
-        count = len(selected)
-        total = len(filtered)
-        lines.append("")
-        lines.append(f"  {green(str(count))} of {total} selected")
-
-        if not first_render:
-            _clear_lines(len(lines))
-        print("\n".join(lines), flush=True)
-        return len(lines)
-
-    def _process_key(key: str, cursor: int, selected: set, search: str) -> tuple[int, set, str, bool]:
-        """Handle one keypress and return updated (cursor, selected, search, should_break).
-
-        Args:
-            key: Keypress token from _read_key().
-            cursor: Current cursor row index in the filtered list.
-            selected: Set of currently selected item names.
-            search: Current search query string.
-
-        Returns:
-            Updated (cursor, selected, search, should_break).
-        """
-        f = _filtered()
-        n = len(f)
-        if key == "UP":
-            cursor = max(0, cursor - 1)
-        elif key == "DOWN":
-            cursor = min(n - 1, cursor + 1)
-        elif key == " ":
-            if f and 0 <= cursor < n:
-                name = f[cursor]["name"]
-                selected.discard(name) if name in selected else selected.add(name)
-        elif key in ("\r", "\n", ""):
-            return cursor, selected, search, True
-        elif key in ("q", "Q", "\x03"):
-            print(red("\nCancelled."))
-            sys.exit(0)
-        elif key == "a":
-            selected = set() if len(selected) == len(items) else {i["name"] for i in items}
-        elif key == "/":
-            search, cursor = "", 0
-        elif key == "\x7f":
-            search, cursor = search[:-1], 0
-        elif key and len(key) == 1 and key.isprintable():
-            search += key
-            cursor = 0
-        return cursor, selected, search, False
-
-    filtered = _filtered()
-    _render(filtered, first_render=True)
+    filtered = _multiselect_filtered(items, search)
+    _multiselect_render(title, items, filtered, selected, cursor, search, first_render=True)
 
     while True:
         key = _read_key()
-        cursor, selected, search, done = _process_key(key, cursor, selected, search)
-        filtered = _filtered()
+        cursor, selected, search, done = _multiselect_process_key(key, cursor, selected, search, items)
+        filtered = _multiselect_filtered(items, search)
         cursor = min(cursor, len(filtered) - 1) if filtered else 0
         if done:
             break
-        _render(filtered)
+        _multiselect_render(title, items, filtered, selected, cursor, search)
 
     print()
     return [i for i in items if i["name"] in selected]
@@ -640,6 +645,38 @@ def _install_plugins(selected_plugins: list, args) -> tuple[int, int]:
     return success_count, fail_count
 
 
+def _read_and_migrate_sources(sources_file: Path) -> dict:
+    """Load plugin-sources.json, migrating legacy schema entries to the flat 'source' key."""
+    data: dict = {"sources": []}
+    if sources_file.exists():
+        try:
+            raw = json.loads(sources_file.read_text(encoding="utf-8"))
+            migrated = []
+            for s in raw.get("sources", []):
+                src = s.get("source") or s.get("github") or s.get("local") or ""
+                if src:
+                    migrated.append({"source": src, "plugins": s.get("plugins", [])})
+            data = {"sources": migrated}
+        except ValueError:
+            pass
+    return data
+
+
+def _determine_source_key(args, plugins_root: Path) -> str:
+    """Resolve the canonical source key (GitHub owner/repo or local path) for registry storage."""
+    if args.source and _is_github_source(args.source):
+        source_key, _ = _parse_github_source(args.source)
+        return source_key
+    if args.source:
+        resolved = Path(args.source).resolve()
+        parts = resolved.parts
+        if "plugins" in parts:
+            plugins_idx = len(parts) - 1 - parts[::-1].index("plugins")
+            return str(Path(*parts[:plugins_idx + 1]))
+        return str(resolved)
+    return str(plugins_root)
+
+
 def _update_sources_registry(selected_plugins: list, args, plugins_root: Path, project_root: Path) -> None:
     """Record installed plugin names in plugin-sources.json.
 
@@ -655,31 +692,9 @@ def _update_sources_registry(selected_plugins: list, args, plugins_root: Path, p
     """
     sources_file = project_root / "plugin-sources.json"
     try:
-        data: dict = {"sources": []}
-        if sources_file.exists():
-            try:
-                raw = json.loads(sources_file.read_text(encoding="utf-8"))
-                migrated = []
-                for s in raw.get("sources", []):
-                    src = s.get("source") or s.get("github") or s.get("local") or ""
-                    if src:
-                        migrated.append({"source": src, "plugins": s.get("plugins", [])})
-                data = {"sources": migrated}
-            except ValueError:
-                pass
+        data = _read_and_migrate_sources(sources_file)
         sources = data.setdefault("sources", [])
-        if args.source and _is_github_source(args.source):
-            source_key, _ = _parse_github_source(args.source)
-        elif args.source:
-            resolved = Path(args.source).resolve()
-            parts = resolved.parts
-            if "plugins" in parts:
-                plugins_idx = len(parts) - 1 - parts[::-1].index("plugins")
-                source_key = str(Path(*parts[:plugins_idx + 1]))
-            else:
-                source_key = str(resolved)
-        else:
-            source_key = str(plugins_root)
+        source_key = _determine_source_key(args, plugins_root)
         installed_names = [p["name"] for p in selected_plugins]
         for s in sources:
             if s.get("source") != source_key:
@@ -719,15 +734,28 @@ def _print_results(success_count: int, fail_count: int, dry_run: bool) -> None:
         print()
 
 
-def main() -> None:
-    """CLI entry point: resolve source, discover plugins, select, install, record.
+def _maybe_init_claude_dir(project_root: Path, args) -> None:
+    """Prompt to create .claude/ if missing, so Claude Code symlinks activate.
 
-    Parses CLI arguments, resolves the plugin source (local path or GitHub
-    shorthand with auto-clone), optionally initialises .claude/ for new
-    projects, presents an interactive TUI for plugin selection (or headless
-    --all / --plugins mode), runs plugin_installer.py for each chosen plugin,
-    updates plugin-sources.json, and prints a final summary.
+    Args:
+        project_root: Repository root to check/create .claude/ within.
+        args: Parsed argparse namespace (yes, dry_run).
     """
+    if (project_root / ".claude").exists() or args.dry_run:
+        return
+    print()
+    print(yellow("  No .claude/ directory found in this project."))
+    try:
+        answer = input(f"  Initialize .claude/ for IDE integration? [{green('Y')}/n] ").strip().lower() if not args.yes else "yes"
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+    if answer in ("", "y", "yes"):
+        (project_root / ".claude").mkdir(exist_ok=True)
+        print(f"  {green('✓')} Created .claude/ — Claude Code symlinks will be activated")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for plugin_add.py."""
     parser = argparse.ArgumentParser(
         description="Interactive plugin installer (for full plugins)"
     )
@@ -740,7 +768,27 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Preview — no files written")
     parser.add_argument("--install-rules", action="store_true", help="Also install plugin rules into CLAUDE.md")
     parser.add_argument("--plugins", type=str, help="Comma-separated list of plugins to install (headless filtering)")
-    args = parser.parse_args()
+    return parser
+
+
+def _abort(message: str, temp_dir: Path | None, code: int) -> None:
+    """Print message, clean up temp_dir if present, and exit with code."""
+    print(message)
+    if temp_dir:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    sys.exit(code)
+
+
+def main() -> None:
+    """CLI entry point: resolve source, discover plugins, select, install, record.
+
+    Parses CLI arguments, resolves the plugin source (local path or GitHub
+    shorthand with auto-clone), optionally initialises .claude/ for new
+    projects, presents an interactive TUI for plugin selection (or headless
+    --all / --plugins mode), runs plugin_installer.py for each chosen plugin,
+    updates plugin-sources.json, and prints a final summary.
+    """
+    args = _build_arg_parser().parse_args()
 
     if not INSTALLER_SCRIPT.exists():
         print(red(f"  Error: plugin_installer.py not found at {INSTALLER_SCRIPT}"))
@@ -749,33 +797,18 @@ def main() -> None:
     plugins_root, temp_dir = _resolve_source(args)
 
     project_root = Path.cwd()
-    if not (project_root / ".claude").exists() and not args.dry_run:
-        print()
-        print(yellow("  No .claude/ directory found in this project."))
-        try:
-            answer = input(f"  Initialize .claude/ for IDE integration? [{green('Y')}/n] ").strip().lower() if not args.yes else "yes"
-        except (EOFError, KeyboardInterrupt):
-            answer = ""
-        if answer in ("", "y", "yes"):
-            (project_root / ".claude").mkdir(exist_ok=True)
-            print(f"  {green('✓')} Created .claude/ — Claude Code symlinks will be activated")
+    _maybe_init_claude_dir(project_root, args)
 
     print(f"  {dim('Discovering plugins...')}", end="", flush=True)
     all_plugins = _discover_plugins(plugins_root)
     print(f"\r  {green(str(len(all_plugins)))} plugins found" + " " * 20)
 
     if not all_plugins:
-        print(red("  No plugins found. Is this a valid agent-plugins-skills repo?"))
-        if temp_dir:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-        sys.exit(1)
+        _abort(red("  No plugins found. Is this a valid agent-plugins-skills repo?"), temp_dir, 1)
 
     selected_plugins = _select_plugins(all_plugins, args)
     if not selected_plugins:
-        print(yellow("  No plugins selected. Exiting."))
-        if temp_dir:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-        sys.exit(0)
+        _abort(yellow("  No plugins selected. Exiting."), temp_dir, 0)
 
     _confirm_install(selected_plugins, args, temp_dir)
     success_count, fail_count = _install_plugins(selected_plugins, args)

--- a/plugins/plugin-manager/scripts/plugin_remove.py
+++ b/plugins/plugin-manager/scripts/plugin_remove.py
@@ -131,6 +131,88 @@ def _load_installed(data: dict) -> list:
 # ---------------------------------------------------------------------------
 # Interactive multi-select (grouped by source, mirrors plugin_add.py)
 # ---------------------------------------------------------------------------
+def _multiselect_filtered(items: list, search: str) -> list:
+    """Filter items by current search query (case-insensitive name/source match)."""
+    q = search.lower()
+    return [i for i in items if q in i["name"].lower() or q in i.get("source", "").lower()]
+
+
+def _multiselect_render(title: str, items: list, filtered: list, selected: set,
+                         cursor: int, search: str, first_render: bool = False) -> int:
+    """Render the TUI removal menu (grouped by source) and return the number of printed lines."""
+    PAGE = 18
+    lines = []
+    lines.append(bold(title))
+    lines.append(dim("  \u2191\u2193 move  |  space select  |  / search  |  a all  |  enter confirm  |  q quit"))
+    if search:
+        lines.append(f"  {dim('Search:')} {cyan(search)}_")
+    else:
+        lines.append(dim("  Type / to search"))
+
+    visible = filtered[max(0, cursor - PAGE // 2): cursor + PAGE]
+    offset = max(0, cursor - PAGE // 2)
+    last_src = None
+
+    for idx, item in enumerate(visible):
+        abs_idx = offset + idx
+        src = item.get("source", "")
+        if src != last_src:
+            lines.append(f"  {dim('─── ' + src + ' ───')}")
+            last_src = src
+        is_cursor = abs_idx == cursor
+        is_selected = item["name"] in selected
+        check = red("[x]") if is_selected else dim("[ ]")
+        name  = cyan(item["name"]) if is_cursor else item["name"]
+        arrow = ">" if is_cursor else " "
+        lines.append(f"  {arrow} {check} {name}")
+
+    count = len(selected)
+    lines.append("")
+    lines.append(f"  {red(str(count))} of {len(filtered)} selected for removal")
+
+    if not first_render:
+        _clear_lines(len(lines))
+    print("\n".join(lines), flush=True)
+    return len(lines)
+
+
+def _multiselect_process_key(key: str, cursor: int, selected: set, search: str,
+                              items: list, filtered: list) -> tuple[int, set, str, bool]:
+    """Handle one keypress in the removal TUI and return updated (cursor, selected, search, should_break)."""
+    if key == "UP":
+        cursor = max(0, cursor - 1)
+    elif key == "DOWN":
+        cursor = min(len(filtered) - 1, cursor + 1)
+    elif key == " ":
+        if filtered and 0 <= cursor < len(filtered):
+            name = filtered[cursor]["name"]
+            if name in selected:
+                selected.discard(name)
+            else:
+                selected.add(name)
+    elif key in ("\r", "\n", ""):
+        return cursor, selected, search, True
+    elif key in ("q", "Q", "\x03"):
+        print(red("\nCancelled."))
+        sys.exit(0)
+    elif key == "a":
+        if len(selected) == len(items):
+            selected.clear()
+        else:
+            selected = {i["name"] for i in items}
+    elif key == "/":
+        search = ""
+        cursor = 0
+    elif key == "\x7f":
+        search = search[:-1]
+        cursor = 0
+    elif key and len(key) == 1 and key.isprintable():
+        if not (search == "" and key == "/"):
+            search += key
+            cursor = 0
+    return cursor, selected, search, False
+
+
 def _multiselect(title: str, items: list) -> list:
     """Interactive arrow-key multi-select TUI for choosing plugins to remove.
 
@@ -151,95 +233,19 @@ def _multiselect(title: str, items: list) -> list:
     selected = set()
     cursor = 0
     search = ""
-    PAGE = 18
 
-    def _filtered() -> list:
-        """Filter items by current search query (case-insensitive name/source match)."""
-        q = search.lower()
-        return [i for i in items if q in i["name"].lower() or q in i.get("source", "").lower()]
-
-    def _render(filtered: list, first_render: bool = False) -> int:
-        """Render the TUI removal menu and return the number of printed lines."""
-        lines = []
-        lines.append(bold(title))
-        lines.append(dim("  \u2191\u2193 move  |  space select  |  / search  |  a all  |  enter confirm  |  q quit"))
-        if search:
-            lines.append(f"  {dim('Search:')} {cyan(search)}_")
-        else:
-            lines.append(dim("  Type / to search"))
-
-        visible = filtered[max(0, cursor - PAGE // 2): cursor + PAGE]
-        offset = max(0, cursor - PAGE // 2)
-        last_src = None
-
-        for idx, item in enumerate(visible):
-            abs_idx = offset + idx
-            src = item.get("source", "")
-            if src != last_src:
-                lines.append(f"  {dim('─── ' + src + ' ───')}")
-                last_src = src
-            is_cursor = abs_idx == cursor
-            is_selected = item["name"] in selected
-            check = red("[x]") if is_selected else dim("[ ]")
-            name  = cyan(item["name"]) if is_cursor else item["name"]
-            arrow = ">" if is_cursor else " "
-            lines.append(f"  {arrow} {check} {name}")
-
-        count = len(selected)
-        lines.append("")
-        lines.append(f"  {red(str(count))} of {len(filtered)} selected for removal")
-
-        if not first_render:
-            _clear_lines(len(lines))
-        print("\n".join(lines), flush=True)
-        return len(lines)
-
-    filtered = _filtered()
-    _render(filtered, first_render=True)
+    filtered = _multiselect_filtered(items, search)
+    _multiselect_render(title, items, filtered, selected, cursor, search, first_render=True)
 
     while True:
         key = _read_key()
-        filtered = _filtered()
-        if not filtered:
-            cursor = 0
-        else:
-            cursor = min(cursor, len(filtered) - 1)
+        filtered = _multiselect_filtered(items, search)
+        cursor = min(cursor, len(filtered) - 1) if filtered else 0
 
-        if key == "UP":
-            cursor = max(0, cursor - 1)
-        elif key == "DOWN":
-            cursor = min(len(filtered) - 1, cursor + 1)
-        elif key == " ":
-            if filtered and 0 <= cursor < len(filtered):
-                name = filtered[cursor]["name"]
-                if name in selected:
-                    selected.discard(name)
-                else:
-                    selected.add(name)
-        elif key in ("\r", "\n", ""):
+        cursor, selected, search, done = _multiselect_process_key(key, cursor, selected, search, items, filtered)
+        if done:
             break
-        elif key in ("q", "Q", "\x03"):
-            print(red("\nCancelled."))
-            sys.exit(0)
-        elif key == "a":
-            if len(selected) == len(items):
-                selected.clear()
-            else:
-                selected = {i["name"] for i in items}
-        elif key == "/":
-            search = ""
-            cursor = 0
-        elif key == "\x7f":
-            search = search[:-1]
-            cursor = 0
-        elif key and len(key) == 1 and key.isprintable():
-            if search == "" and key == "/":
-                pass
-            else:
-                search += key
-                cursor = 0
-
-        _render(filtered)
+        _multiselect_render(title, items, filtered, selected, cursor, search)
 
     print()
     return [i for i in items if i["name"] in selected]
@@ -254,6 +260,63 @@ AGENT_DIRS = {
     "gemini": [".gemini/commands", ".gemini/skills", ".gemini/rules"],
     "claude": [".claude/commands", ".claude/skills", ".claude/rules", ".claude/agents", ".claude/hooks"]
 }
+
+def _remove_via_ownership_manifest(ownership_file: Path, root: Path, dry_run: bool) -> int:
+    """Remove all artifacts listed in a plugin's ownership manifest; return count removed."""
+    removed_count = 0
+    print(f"    - Using ownership manifest: {ownership_file.relative_to(root)}")
+    try:
+        data = json.loads(ownership_file.read_text(encoding="utf-8"))
+        artifacts = data.get("artifacts", [])
+
+        # Sort artifacts by length in descending order so files are unlinked/removed before parent directories
+        for art_rel in sorted(artifacts, key=len, reverse=True):
+            art_path = root / art_rel
+            if art_path.exists():
+                print(f"    - Removing owned artifact: {art_rel}")
+                if not dry_run:
+                    if art_path.is_symlink() or (hasattr(os.path, 'isjunction') and os.path.isjunction(art_path)):
+                        art_path.unlink()
+                    elif art_path.is_dir():
+                        shutil.rmtree(art_path)
+                    else:
+                        art_path.unlink()
+                removed_count += 1
+        if not dry_run:
+            ownership_file.unlink()
+            print(f"    - Removed ownership manifest: {ownership_file.relative_to(root)}")
+    except Exception as e:
+        print(f"    Warning: Failed to clean via ownership manifest: {e}")
+    return removed_count
+
+
+def _remove_via_legacy_scan(plugin_name: str, root: Path, dry_run: bool) -> int:
+    """Fallback cleanup: scan AGENT_DIRS for items matching the plugin name pattern; return count removed."""
+    removed_count = 0
+    for agent, dirs in AGENT_DIRS.items():
+        for dir_path in dirs:
+            target_dir = root / dir_path
+            if not target_dir.exists():
+                continue
+
+            for item in target_dir.iterdir():
+                if item.is_dir() and item.name == plugin_name:
+                    print(f"    - Removing legacy directory: {item.relative_to(root)}")
+                    if not dry_run:
+                        if item.is_symlink() or (hasattr(os.path, 'isjunction') and os.path.isjunction(item)):
+                            item.unlink()
+                        else:
+                            shutil.rmtree(item)
+                    removed_count += 1
+                elif item.is_file():
+                    # Files: {plugin_name}_{command}.* or {plugin_name}-{agent}.*
+                    if item.name.startswith(f"{plugin_name}_") or item.name.startswith(f"{plugin_name}-"):
+                        print(f"    - Removing legacy file: {item.relative_to(root)}")
+                        if not dry_run:
+                            item.unlink()
+                        removed_count += 1
+    return removed_count
+
 
 def remove_plugin_artifacts(plugin_name: str, root: Path, dry_run: bool) -> int:
     """Delete all deployed files for a plugin from the agent environment directories.
@@ -271,57 +334,15 @@ def remove_plugin_artifacts(plugin_name: str, root: Path, dry_run: bool) -> int:
         Count of artifact paths removed (or that would be removed in dry-run).
     """
     ownership_file = root / ".agents" / "ownership" / f"{plugin_name}.json"
-    
-    if ownership_file.exists():
-        print(f"    - Using ownership manifest: {ownership_file.relative_to(root)}")
-        try:
-            data = json.loads(ownership_file.read_text(encoding="utf-8"))
-            artifacts = data.get("artifacts", [])
-            
-            # Sort artifacts by length in descending order so files are unlinked/removed before parent directories
-            for art_rel in sorted(artifacts, key=len, reverse=True):
-                art_path = root / art_rel
-                if art_path.exists():
-                    print(f"    - Removing owned artifact: {art_rel}")
-                    if not dry_run:
-                        if art_path.is_symlink() or (hasattr(os.path, 'isjunction') and os.path.isjunction(art_path)):
-                            art_path.unlink()
-                        elif art_path.is_dir():
-                            shutil.rmtree(art_path)
-                        else:
-                            art_path.unlink()
-                    removed_count += 1
-            if not dry_run:
-                ownership_file.unlink()
-                print(f"    - Removed ownership manifest: {ownership_file.relative_to(root)}")
-        except Exception as e:
-            print(f"    Warning: Failed to clean via ownership manifest: {e}")
-            # Fall back to legacy cleanup below
-            
-    # Legacy fallback if no ownership file exists or it failed
-    if not ownership_file.exists() or removed_count == 0:
-        for agent, dirs in AGENT_DIRS.items():
-            for dir_path in dirs:
-                target_dir = root / dir_path
-                if not target_dir.exists():
-                    continue
+    removed_count = 0
 
-                for item in target_dir.iterdir():
-                    if item.is_dir() and item.name == plugin_name:
-                        print(f"    - Removing legacy directory: {item.relative_to(root)}")
-                        if not dry_run:
-                            if item.is_symlink() or (hasattr(os.path, 'isjunction') and os.path.isjunction(item)):
-                                item.unlink()
-                            else:
-                                shutil.rmtree(item)
-                        removed_count += 1
-                    elif item.is_file():
-                        # Files: {plugin_name}_{command}.* or {plugin_name}-{agent}.*
-                        if item.name.startswith(f"{plugin_name}_") or item.name.startswith(f"{plugin_name}-"):
-                            print(f"    - Removing legacy file: {item.relative_to(root)}")
-                            if not dry_run:
-                                item.unlink()
-                            removed_count += 1
+    if ownership_file.exists():
+        removed_count = _remove_via_ownership_manifest(ownership_file, root, dry_run)
+
+    # Legacy fallback if no ownership file exists or it removed nothing
+    if not ownership_file.exists() or removed_count == 0:
+        removed_count += _remove_via_legacy_scan(plugin_name, root, dry_run)
+
     return removed_count
 
 
@@ -377,21 +398,20 @@ def _remove_from_registries(plugin_name: str, root: Path, dry_run: bool) -> None
              print(yellow(f"    Warning: Failed updating skills-lock.json: {e}"))
 
 
-def main() -> None:
-    """CLI entry point: load installed plugins, prompt for selection, remove artifacts.
+def _print_removal_banner() -> None:
+    """Print the ASCII art plugin remover banner."""
+    print()
+    print(bold("  ██████╗ ███████╗███╗   ███╗ ██████╗ ██╗   ██╗███████╗"))
+    print(bold("  ██╔══██╗██╔════╝████╗ ████║██╔═══██╗██║   ██║██╔════╝"))
+    print(bold("  ██████╔╝█████╗  ██╔████╔██║██║   ██║██║   ██║█████╗  "))
+    print(bold("  ██╔══██╗██╔══╝  ██║╚██╔╝██║██║   ██║╚██╗ ██╔╝██╔══╝  "))
+    print(bold("  ██║  ██║███████╗██║ ╚═╝ ██║╚██████╔╝ ╚████╔╝ ███████╗"))
+    print(bold("  ╚═╝  ╚═╝╚══════╝╚═╝     ╚═╝ ╚═════╝   ╚═══╝  ╚══════╝"))
+    print()
 
-    Reads plugin-sources.json to build the installed plugin list, presents the
-    interactive TUI (or uses --plugins/--all for headless mode), calls
-    remove_plugin_artifacts and _remove_from_registries for each selected plugin.
-    """
-    parser = argparse.ArgumentParser(description="Interactive plugin remover")
-    parser.add_argument("--dry-run", action="store_true", help="Preview deletions without removing")
-    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts (headless)")
-    parser.add_argument("--all", "-a", action="store_true", help="Select all plugins without prompting")
-    parser.add_argument("--plugins", type=str, help="Comma-separated list of plugins to remove (headless filtering)")
-    args = parser.parse_args()
 
-    project_root = Path.cwd()
+def _load_installed_or_exit(project_root: Path) -> list:
+    """Read plugin-sources.json and return the installed plugin list, or exit if unavailable."""
     sources_file = project_root / "plugin-sources.json"
 
     if not sources_file.exists():
@@ -410,36 +430,55 @@ def main() -> None:
         print(yellow("No plugins currently recorded in plugin-sources.json."))
         sys.exit(0)
 
+    return installed_plugins
+
+
+def _select_plugins_to_remove(installed_plugins: list, args) -> list:
+    """Return the subset of installed plugins to remove based on CLI flags or TUI."""
     if args.plugins:
         allowed = set(p.strip() for p in args.plugins.split(","))
-        selected = [p for p in installed_plugins if p["name"] in allowed]
-    elif args.all or args.yes:
-        selected = installed_plugins
-    else:
-        print()
-        print(bold("  ██████╗ ███████╗███╗   ███╗ ██████╗ ██╗   ██╗███████╗"))
-        print(bold("  ██╔══██╗██╔════╝████╗ ████║██╔═══██╗██║   ██║██╔════╝"))
-        print(bold("  ██████╔╝█████╗  ██╔████╔██║██║   ██║██║   ██║█████╗  "))
-        print(bold("  ██╔══██╗██╔══╝  ██║╚██╔╝██║██║   ██║╚██╗ ██╔╝██╔══╝  "))
-        print(bold("  ██║  ██║███████╗██║ ╚═╝ ██║╚██████╔╝ ╚████╔╝ ███████╗"))
-        print(bold("  ╚═╝  ╚═╝╚══════╝╚═╝     ╚═╝ ╚═════╝   ╚═══╝  ╚══════╝"))
-        print()
+        return [p for p in installed_plugins if p["name"] in allowed]
+    if args.all or args.yes:
+        return installed_plugins
+    _print_removal_banner()
+    return _multiselect("  Select plugins to remove", installed_plugins)
 
-        selected = _multiselect("  Select plugins to remove", installed_plugins)
+
+def _remove_selected_plugins(selected: list, project_root: Path, dry_run: bool) -> None:
+    """Remove artifacts and registry entries for each selected plugin."""
+    print(f"\nProceeding to remove {len(selected)} plugins...")
+    for p in selected:
+        pname = p["name"]
+        print(f"\n{bold(pname)}:")
+        artifacts_removed = remove_plugin_artifacts(pname, project_root, dry_run)
+        _remove_from_registries(pname, project_root, dry_run)
+        if artifacts_removed == 0:
+            print(dim("    (no file artifacts found)"))
+
+
+def main() -> None:
+    """CLI entry point: load installed plugins, prompt for selection, remove artifacts.
+
+    Reads plugin-sources.json to build the installed plugin list, presents the
+    interactive TUI (or uses --plugins/--all for headless mode), calls
+    remove_plugin_artifacts and _remove_from_registries for each selected plugin.
+    """
+    parser = argparse.ArgumentParser(description="Interactive plugin remover")
+    parser.add_argument("--dry-run", action="store_true", help="Preview deletions without removing")
+    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts (headless)")
+    parser.add_argument("--all", "-a", action="store_true", help="Select all plugins without prompting")
+    parser.add_argument("--plugins", type=str, help="Comma-separated list of plugins to remove (headless filtering)")
+    args = parser.parse_args()
+
+    project_root = Path.cwd()
+    installed_plugins = _load_installed_or_exit(project_root)
+    selected = _select_plugins_to_remove(installed_plugins, args)
 
     if not selected:
         print(yellow("  No plugins selected. Exiting."))
         sys.exit(0)
 
-    print(f"\nProceeding to remove {len(selected)} plugins...")
-    
-    for p in selected:
-        pname = p["name"]
-        print(f"\n{bold(pname)}:")
-        artifacts_removed = remove_plugin_artifacts(pname, project_root, args.dry_run)
-        _remove_from_registries(pname, project_root, args.dry_run)
-        if artifacts_removed == 0:
-             print(dim("    (no file artifacts found)"))
+    _remove_selected_plugins(selected, project_root, args.dry_run)
 
     print()
     if args.dry_run:

--- a/plugins/plugin-manager/scripts/sync_with_inventory.py
+++ b/plugins/plugin-manager/scripts/sync_with_inventory.py
@@ -182,16 +182,13 @@ def sync_source(source_key: str, plugins: list, root: Path, dry_run: bool) -> No
         print(f"  [ERROR] Failed syncing source '{source_key}': {e}")
 
 
-def validate_agents_state(root: Path, registered_plugins: set) -> None:
-    """Scan installed directories and report validation issues."""
+def _find_missing_artifacts(root: Path, registered_plugins: set) -> list:
+    """Return descriptions of missing ownership-tracked artifacts or central copies."""
     missing = []
-    unexpected = []
-    
-    # 1. Check for missing ownership manifests or central copies
     for pname in registered_plugins:
         ownership_file = root / ".agents" / "ownership" / f"{pname}.json"
         central_dir = root / ".agents" / "skills" / pname
-        
+
         if not ownership_file.exists():
             # Fallback checks
             lock_file = root / "skills-lock.json"
@@ -213,8 +210,12 @@ def validate_agents_state(root: Path, registered_plugins: set) -> None:
                         missing.append(f"{pname} (artifact missing: {art})")
             except Exception:
                 pass
-                
-    # 2. Check for unexpected directories in .agents/skills/
+    return missing
+
+
+def _find_unexpected_skill_dirs(root: Path, registered_plugins: set) -> list:
+    """Return descriptions of orphaned directories under .agents/skills/."""
+    unexpected = []
     skills_dir = root / ".agents" / "skills"
     valid_skills = set()
     for pname in registered_plugins:
@@ -228,7 +229,7 @@ def validate_agents_state(root: Path, registered_plugins: set) -> None:
                         valid_skills.add(path_parts[2])
             except Exception:
                 pass
-        
+
         # Fallback local discovery
         plugin_src = root / "plugins" / pname
         if plugin_src.exists() and (plugin_src / "skills").is_dir():
@@ -240,8 +241,14 @@ def validate_agents_state(root: Path, registered_plugins: set) -> None:
         for item in skills_dir.iterdir():
             if item.is_dir() and item.name not in valid_skills:
                 unexpected.append(f"Orphaned skill directory: {item.relative_to(root)}")
+    return unexpected
 
-                
+
+def validate_agents_state(root: Path, registered_plugins: set) -> None:
+    """Scan installed directories and report validation issues."""
+    missing = _find_missing_artifacts(root, registered_plugins)
+    unexpected = _find_unexpected_skill_dirs(root, registered_plugins)
+
     if missing or unexpected:
         print("  ⚠️ Validation issues detected:")
         for m in missing:
@@ -250,6 +257,65 @@ def validate_agents_state(root: Path, registered_plugins: set) -> None:
             print(f"    - Unexpected: {u}")
     else:
         print("  ✓ Verification Complete: All registered plugins are clean and accounted for.")
+
+
+def _read_sources_registry(root: Path) -> tuple:
+    """Read plugin-sources.json and return (registered_plugin_names, sources_data).
+
+    Supports both the new schema ({"source": ..., "plugins": [...]}) and
+    legacy schema ({"local"/"github"/"name": ..., "plugins": [...]}).
+    """
+    registered_set = get_installed_plugin_names(root)
+    sources_file = root / "plugin-sources.json"
+    sources_data = []
+    if sources_file.exists():
+        try:
+            raw = json.loads(sources_file.read_text(encoding="utf-8"))
+            for s in raw.get("sources", []):
+                src = s.get("source") or s.get("github") or s.get("local") or s.get("name", "")
+                plugs = s.get("plugins", [])
+                if src and isinstance(plugs, list) and plugs:
+                    sources_data.append({"source": src, "plugins": plugs})
+        except Exception as e:
+            print(f"  Error reading plugin-sources.json: {e}")
+
+    print(f"  {len(registered_set)} registered plugins across {len(sources_data)} sources:")
+    for s in sources_data:
+        print(f"    [{s['source']}] -> {', '.join(s['plugins'])}")
+    return registered_set, sources_data
+
+
+def _cleanup_stale_sources(sources_data: list, root: Path, dry_run: bool) -> None:
+    """Detect locally-sourced plugins whose source directory is gone and clean them up."""
+    stale = set()
+    for s in sources_data:
+        src = s["source"]
+        # Only check stale for local paths (not GitHub slugs)
+        if src.startswith("/") or src.startswith("./") or src.startswith("plugins/"):
+            src_path = Path(src) if src.startswith("/") else root / src
+            if not src_path.exists():
+                stale.update(s["plugins"])
+                print(f"  Stale source (path gone): {src} -> {s['plugins']}")
+
+    if stale:
+        print(f"  Cleaning {len(stale)} stale plugin(s)...")
+        for plugin in sorted(stale):
+            clean_plugin_artifacts(plugin, root, dry_run)
+    else:
+        print("  No stale local sources detected.")
+
+
+def _sync_all_registered_sources(sources_data: list, root: Path, dry_run: bool) -> None:
+    """Call sync_source for every registered source entry to reinstall its plugins."""
+    if not sources_data:
+        print("  No sources registered in plugin-sources.json. Nothing to sync.")
+        print("  Run plugin_add.py to register and install plugins first.")
+        return
+    for s in sources_data:
+        if s["plugins"]:
+            src = s["source"]
+            print(f"\n  Source: {src}")
+            sync_source(src, s["plugins"], root, dry_run)
 
 
 def main() -> None:
@@ -267,66 +333,18 @@ def main() -> None:
 
     root = Path.cwd()
 
-    # 1. Read plugin-sources.json — authoritative registry of ALL installed plugins
     print("--- 1. Reading plugin-sources.json Registry ---")
-    registered_set = get_installed_plugin_names(root)
-    sources_file = root / "plugin-sources.json"
-    sources_data = []
-    if sources_file.exists():
-        try:
-            raw = json.loads(sources_file.read_text(encoding="utf-8"))
-            for s in raw.get("sources", []):
-                # Support both new (source) and legacy (local/github/name) schema
-                src = s.get("source") or s.get("github") or s.get("local") or s.get("name", "")
-                plugs = s.get("plugins", [])
-                if src and isinstance(plugs, list) and plugs:
-                    sources_data.append({"source": src, "plugins": plugs})
-        except Exception as e:
-            print(f"  Error reading plugin-sources.json: {e}")
+    registered_set, sources_data = _read_sources_registry(root)
 
-    print(f"  {len(registered_set)} registered plugins across {len(sources_data)} sources:")
-    for s in sources_data:
-        print(f"    [{s['source']}] -> {', '.join(s['plugins'])}")
-
-# plugin_inventory dependency removed
-
-    # 3. Cleanup: plugins in registry that no longer have a local source dir
-    #    (only applies to locally-sourced plugins where the dir was deleted)
     print("\n--- 3. Cleanup Analysis ---")
-    # Detect locally-sourced plugins whose source dir is gone
-    stale = set()
-    for s in sources_data:
-        src = s["source"]
-        # Only check stale for local paths (not GitHub slugs)
-        if src.startswith("/") or src.startswith("./") or src.startswith("plugins/"):
-            src_path = Path(src) if src.startswith("/") else root / src
-            if not src_path.exists():
-                stale.update(s["plugins"])
-                print(f"  Stale source (path gone): {src} -> {s['plugins']}")
+    _cleanup_stale_sources(sources_data, root, args.dry_run)
 
-    if stale:
-        print(f"  Cleaning {len(stale)} stale plugin(s)...")
-        for plugin in sorted(stale):
-            clean_plugin_artifacts(plugin, root, args.dry_run)
-    else:
-        print("  No stale local sources detected.")
-
-    # 4. Reinstall — call plugin_add.py per source entry so all plugins are redeployed
     if not args.cleanup_only:
         print(f"\n--- 4. Syncing All Registered Plugins ---")
-        if not sources_data:
-            print("  No sources registered in plugin-sources.json. Nothing to sync.")
-            print("  Run plugin_add.py to register and install plugins first.")
-        else:
-            for s in sources_data:
-                if s["plugins"]:
-                    src = s["source"]
-                    print(f"\n  Source: {src}")
-                    sync_source(src, s["plugins"], root, args.dry_run)
+        _sync_all_registered_sources(sources_data, root, args.dry_run)
     else:
         print("\nSkipping reinstall (--cleanup-only).")
 
-    # 5. Post-Sync Validation
     print("\n--- 5. Post-Sync Validation ---")
     if not args.dry_run:
         validate_agents_state(root, registered_set)

--- a/plugins/plugin-manager/scripts/test_plugin_lifecycle.py
+++ b/plugins/plugin-manager/scripts/test_plugin_lifecycle.py
@@ -95,6 +95,44 @@ def verify_no_duplicates(plugin_name: str) -> None:
     print(f"  PASS No duplicates for '{plugin_name}'")
 
 
+def _run_github_phases(python_exec: str, add_script: str, remove_script: str, sync_script: str,
+                        github_source: str, plugin_name: str) -> None:
+    """Run phases 1-4: GitHub install, idempotency check, sync, and remove."""
+    print("\n[Phase 1] Install via GitHub source")
+    run_command([python_exec, add_script, github_source, "--plugins", plugin_name, "--yes"])
+    verify_sources("After GitHub install", plugin_name, expect_present=True)
+
+    print("\n[Phase 2] Re-install (idempotency)")
+    run_command([python_exec, add_script, github_source, "--plugins", plugin_name, "--yes"])
+    verify_sources("After re-install", plugin_name, expect_present=True)
+    verify_no_duplicates(plugin_name)
+
+    print("\n[Phase 3] Sync via inventory script")
+    run_command([python_exec, sync_script])
+    verify_sources("After sync", plugin_name, expect_present=True)
+    verify_no_duplicates(plugin_name)
+
+    print("\n[Phase 4] Remove via headless flag")
+    run_command([python_exec, remove_script, "--plugins", plugin_name, "--yes"])
+    verify_sources("After remove", plugin_name, expect_present=False)
+
+
+def _run_local_phases(python_exec: str, add_script: str, remove_script: str, sync_script: str,
+                       local_source: str, plugin_name: str) -> None:
+    """Run phases 5-7: local install, local sync, and local remove."""
+    print("\n[Phase 5] Install via local source")
+    run_command([python_exec, add_script, local_source, "--yes"])
+    verify_sources("After local install", plugin_name, expect_present=True)
+
+    print("\n[Phase 6] Sync local inventory")
+    run_command([python_exec, sync_script])
+    verify_sources("After local sync", plugin_name, expect_present=True)
+
+    print("\n[Phase 7] Remove local install")
+    run_command([python_exec, remove_script, "--plugins", plugin_name, "--yes"])
+    verify_sources("After local remove", plugin_name, expect_present=False)
+
+
 def main() -> None:
     """Run the 7-phase plugin lifecycle test using agent-loops as the test subject.
 
@@ -115,42 +153,8 @@ def main() -> None:
     local_source = "plugins/agent-loops"
     plugin_name = "agent-loops"
 
-    # Phase 1: GitHub install
-    print("\n[Phase 1] Install via GitHub source")
-    run_command([python_exec, add_script, github_source, "--plugins", plugin_name, "--yes"])
-    verify_sources("After GitHub install", plugin_name, expect_present=True)
-
-    # Phase 2: Idempotency check
-    print("\n[Phase 2] Re-install (idempotency)")
-    run_command([python_exec, add_script, github_source, "--plugins", plugin_name, "--yes"])
-    verify_sources("After re-install", plugin_name, expect_present=True)
-    verify_no_duplicates(plugin_name)
-
-    # Phase 3: Sync Inventory
-    print("\n[Phase 3] Sync via inventory script")
-    run_command([python_exec, sync_script])
-    verify_sources("After sync", plugin_name, expect_present=True)
-    verify_no_duplicates(plugin_name)
-
-    # Phase 4: Remove
-    print("\n[Phase 4] Remove via headless flag")
-    run_command([python_exec, remove_script, "--plugins", plugin_name, "--yes"])
-    verify_sources("After remove", plugin_name, expect_present=False)
-
-    # Phase 5: Local install
-    print("\n[Phase 5] Install via local source")
-    run_command([python_exec, add_script, local_source, "--yes"])
-    verify_sources("After local install", plugin_name, expect_present=True)
-
-    # Phase 6: Sync Inventory locally
-    print("\n[Phase 6] Sync local inventory")
-    run_command([python_exec, sync_script])
-    verify_sources("After local sync", plugin_name, expect_present=True)
-
-    # Phase 7: Remove again
-    print("\n[Phase 7] Remove local install")
-    run_command([python_exec, remove_script, "--plugins", plugin_name, "--yes"])
-    verify_sources("After local remove", plugin_name, expect_present=False)
+    _run_github_phases(python_exec, add_script, remove_script, sync_script, github_source, plugin_name)
+    _run_local_phases(python_exec, add_script, remove_script, sync_script, local_source, plugin_name)
 
     print("\n" + "=" * 52)
     print("  All Lifecycle Tests Passed!")


### PR DESCRIPTION
Extracts nested/inline logic into module-level helper functions to bring all flagged functions under the 50-line threshold in coding-conventions.md. No behavior changes intended, verified via py_compile and --dry-run smoke tests against plugin_add.py and plugin_remove.py.

- sync_with_inventory.py: validate_agents_state -> _find_missing_artifacts + _find_unexpected_skill_dirs; main -> _read_sources_registry + _cleanup_stale_sources + _sync_all_registered_sources
- plugin_add.py: _multiselect's nested _filtered/_render/_process_key promoted to module-level _multiselect_filtered/_render/_process_key; _update_sources_registry -> _read_and_migrate_sources + _determine_source_key; main -> _build_arg_parser + _maybe_init_claude_dir + _abort
- plugin_remove.py: same _multiselect extraction pattern; fixes a real bug in remove_plugin_artifacts where removed_count was referenced before initialization (UnboundLocalError crash on any removal that hit the ownership-manifest branch), split into _remove_via_ownership_manifest + _remove_via_legacy_scan; main -> _print_removal_banner + _load_installed_or_exit + _select_plugins_to_remove + _remove_selected_plugins
- test_plugin_lifecycle.py: main -> _run_github_phases + _run_local_phases