### PR TITLE
feat: add Key-Functions freshness check to conventions auditor

### DIFF
--- a/plugins/agent-loops/scripts/agent_orchestrator.py
+++ b/plugins/agent-loops/scripts/agent_orchestrator.py
@@ -15,9 +15,10 @@ Key Input Dependencies:
   - Optional: context bundle JSON
 
 Key Functions:
-  - generate_packet(): Create strategy packet from parameters
-  - verify_worktree(): Check git diff against criteria
-  - correct_packet(): Generate correction/delta packet
+  - cmd_packet(): Create strategy packet from parameters
+  - cmd_verify(): Check git diff against criteria
+  - cmd_correct(): Generate correction/delta packet
+  - cmd_retro(): Generate retrospective template
 
 Commands:
   packet    -> Generate strategy packet from inputs

--- a/plugins/agent-loops/scripts/closure_guard.py
+++ b/plugins/agent-loops/scripts/closure_guard.py
@@ -16,7 +16,7 @@ Key Input Dependencies:
 
 Key Functions:
     - parse_frontmatter(): Extract YAML frontmatter from markdown file
-    - check_closure_done(): Check if loop is ready for session exit
+    - _handle_closure_done(): Check if loop is ready for session exit
 
 Layer: Investigate
 

--- a/plugins/agent-loops/scripts/swarm_run.py
+++ b/plugins/agent-loops/scripts/swarm_run.py
@@ -18,7 +18,7 @@ Key Input Dependencies:
 Key Functions:
     - get_relative_path(): Convert absolute path to relative
     - resolve_files(): Discover input files from various sources
-    - run_worker(): Execute Claude with prompt and handle output
+    - execute_worker(): Execute the LLM engine with a prompt and handle output
 
 WHAT IS A JOB FILE?
     A Job File is a single Markdown file (.md) that bundles ALL configuration

--- a/plugins/agent-scaffolders/scripts/test_hook.py
+++ b/plugins/agent-scaffolders/scripts/test_hook.py
@@ -21,8 +21,9 @@ Key Input Dependencies:
     - Test input JSON file (Claude Code hook event payload)
 
 Key Functions:
-    - create_sample(): Generate sample hook payloads for testing
-    - test_hook(): Execute hook script and parse results
+    - _create_sample(): Generate sample hook payloads for testing
+    - _run_hook(): Execute hook script and capture its output
+    - main(): CLI entry point — validate args, run the hook, report results
 """
 import sys
 import os

--- a/plugins/dev-utils/scripts/hf_download.py
+++ b/plugins/dev-utils/scripts/hf_download.py
@@ -4,7 +4,7 @@ HuggingFace Download Primitives
 Purpose:
     Consolidated download operations for HuggingFace assets.
     All HF-consuming plugins (Primary Agent, local-llm-bench, etc.) use these primitives.
-    Includes exponential backoff and support for downloading files, folders, and model checkpoints.
+    Includes exponential backoff and support for downloading files and folders.
 
 Key Input Dependencies:
     - hf_config module (for HuggingFace configuration and API credentials)
@@ -16,7 +16,6 @@ Key Functions:
     - _download_with_backoff(): Execute HF API calls with exponential backoff
     - download_file(): Download single file from HuggingFace
     - download_folder(): Download entire folder/dataset from HuggingFace
-    - download_model_checkpoint(): Download model checkpoint with cache support
 """
 import os
 import sys

--- a/plugins/dev-utils/scripts/hf_upload.py
+++ b/plugins/dev-utils/scripts/hf_upload.py
@@ -16,7 +16,7 @@ Key Functions:
     - _build_dataset_readme(): Generate dataset README.md from config
     - upload_file(): Upload single file to HuggingFace
     - upload_folder(): Upload entire folder/dataset to HuggingFace
-    - append_jsonl(): Append rows to HuggingFace dataset via JSONL
+    - append_to_jsonl(): Append rows to HuggingFace dataset via JSONL
 """
 import os
 import sys

--- a/plugins/dev-utils/scripts/workspace_conventions_auditor.py
+++ b/plugins/dev-utils/scripts/workspace_conventions_auditor.py
@@ -45,6 +45,61 @@ EXCLUDE_FILES = {
 SUPPORTED_EXTENSIONS = {".py", ".ts", ".tsx", ".js"}
 
 
+# Extract the 'Key Functions:' block from a module docstring, if present
+def _extract_key_functions_section(docstring: str) -> str:
+    """Return the text of the docstring block whose first line mentions 'Key Functions'."""
+    blocks = re.split(r"\n\s*\n", docstring)
+    for block in blocks:
+        stripped = block.strip()
+        if stripped and "key functions" in stripped.splitlines()[0].lower():
+            return block
+    return ""
+
+
+# Collect every function/method name and class name actually defined in the parsed file
+def _collect_defined_names(tree: ast.AST) -> tuple:
+    """Return (defined_names, defined_classes).
+
+    defined_names includes plain function names and 'ClassName.method_name' pairs.
+    defined_classes is the set of locally-defined class names, used to distinguish
+    genuine local method references from external module calls (e.g. os.walk()).
+    """
+    defined = set()
+    classes = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            defined.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            classes.add(node.name)
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    defined.add(f"{node.name}.{item.name}")
+    return defined, classes
+
+
+# Flag 'Key Functions' entries that reference a function no longer in the file
+def _check_key_functions_freshness(docstring: str, tree: ast.AST) -> List[str]:
+    """Detect stale 'Key Functions' references (renamed/removed functions).
+
+    Dotted references (e.g. 'os.walk()') are only checked when the prefix is a
+    locally-defined class — otherwise they're treated as external module calls
+    mentioned in prose, not a promise about this file's own function set.
+    """
+    section = _extract_key_functions_section(docstring)
+    if not section:
+        return []
+    defined_names, defined_classes = _collect_defined_names(tree)
+    errors = []
+    for name in re.findall(r"([A-Za-z_][A-Za-z0-9_.]*)\(\)", section):
+        if "." in name:
+            prefix = name.rpartition(".")[0]
+            if prefix not in defined_classes:
+                continue
+        if name not in defined_names:
+            errors.append(f"Header 'Key Functions' references '{name}()', which no longer exists in this file.")
+    return errors
+
+
 # External comment: Audit a Python file for standard formatting structure
 def scan_python_file(file_path: Path) -> List[str]:
     """Audits a Python file for standards using AST parsing."""
@@ -67,6 +122,7 @@ def scan_python_file(file_path: Path) -> List[str]:
             errors.append("Header is missing 'Purpose:' section.")
         if "key input dependencies:" not in doc_lower and "dependencies:" not in doc_lower:
             errors.append("Header is missing 'Key Input Dependencies:' section.")
+        errors.extend(_check_key_functions_freshness(docstring, tree))
 
     # 2. Function checks
     for node in ast.walk(tree):


### PR DESCRIPTION
## Summary
- Added a check to `workspace_conventions_auditor.py` that flags module docstring `Key Functions` entries referencing a function that no longer exists in the file (catches rename/delete drift after refactors). Dotted references (`os.walk()`) are only checked when the prefix is a locally-defined class, so external module calls mentioned in prose aren't false-flagged.
- Fixed the 6 real stale references it found across `agent-loops` and `dev-utils` (pre-existing, unrelated to this session's earlier coding-conventions pass).

## Test plan
- [x] `py_compile` on all 7 changed files
- [x] Full workspace audit: 9/9 plugins, 198/198 canonical files, 479/479 references passing
- [x] `symlink_manager.py diagnose` — no broken/imposter links
- [x] Sanity-tested the new check against synthetic fresh/stale fixtures before running on the real workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)