### PR TITLE
feat(dev-utils): expand context-bundler persona templates taxonomy

### DIFF
--- a/plugins/dev-utils/skills/context-bundler/SKILL.md
+++ b/plugins/dev-utils/skills/context-bundler/SKILL.md
@@ -3,8 +3,8 @@ name: context-bundler
 plugin: dev-utils
 description: >
   Interactively creates targeted code, design, and documentation bundles for external review (Markdown or ZIP).
-  Supports Red Team review personas (Adversarial Security, Structural Architecture, Compliance Standards),
-  full monorepo segmentation, and custom file manifest packaging.
+  Includes a comprehensive library of review & delegation persona templates (Adversarial Security, Plan Critique,
+  Refactoring Quality, Sub-Agent Task Handoff, Documentation Synthesis, Architecture, Compliance).
 allowed-tools: Bash, Read, Write, Glob, Grep
 ---
 
@@ -21,18 +21,27 @@ This skill centralizes workflows for compiling codebase files, documentation, an
 
 `context-bundler` supports **3 Execution Modes**:
 1. **Standard Bundle Mode**: Custom interactive selection of files/directories for general review or context sharing.
-2. **Red Team Review Mode**: Injects specialized review persona prompts (Adversarial Security, Structural Architecture, Compliance Standards) as `prompt.md` ahead of codebase files.
+2. **Persona-Driven Review / Handoff Mode**: Injects specialized review or delegation persona prompts (`prompt.md`) ahead of codebase files.
 3. **Monorepo Segmented Mode**: Full monorepo context packaging partitioned by domain (`/skills`, `/agents`, `/scripts`, `/docs`).
 
 ---
 
-## 🎭 Persona Templates (Red Team & Specialized Review Modes)
+## 🎭 Persona Template Library (`assets/templates/`)
 
-When running in **Red Team Review Mode**, select or recommend a review persona template from `assets/templates/`:
+When bundling context for external models, sub-agents, or human reviews, select or recommend a template from `assets/templates/`:
 
-- **`adversarial-security-auditor.md`**: Focuses on OWASP Top 10, auth bypasses, injection vectors, and severity scoring (Critical/High/Medium/Low).
-- **`structural-architecture-reviewer.md`**: Focuses on C4 models, SOLID principles, coupling, modularity, and refactoring blueprints.
-- **`compliance-standards-reviewer.md`**: Focuses on project conventions, 20-line purpose headers, ADR compliance, and type annotation audits.
+### 1. Security & Quality Review Personas
+- **`adversarial-security-auditor.md`**: OWASP Top 10, auth bypasses, injection vectors, exploit scenarios, CVSS risk ratings.
+- **`refactoring-quality-specialist.md`**: DRY violations, code smells, cyclomatic complexity reduction, before/after code diffs.
+- **`compliance-standards-reviewer.md`**: Project conventions, 20-line purpose headers, ADR compliance, type annotations.
+
+### 2. Architecture & Design Planning Personas
+- **`structural-architecture-reviewer.md`**: C4 model, SOLID principles, coupling, interface abstraction leaks, component boundaries.
+- **`plan-critique-reviewer.md`**: Stress-tests implementation plans, unstated dependencies, execution friction, rollback mechanisms.
+
+### 3. Agent Task Handoff & Documentation Personas
+- **`agent-task-delegator.md`**: Builds turnkey task prompts for sub-agents (Copilot CLI, Claude Code, Gemini CLI) with explicit tool gates & test criteria.
+- **`docs-synthesis-specialist.md`**: Generates ADRs, C4 Mermaid diagrams, README guides, and API specs from raw codebase context.
 
 ---
 
@@ -40,7 +49,7 @@ When running in **Red Team Review Mode**, select or recommend a review persona t
 
 ### Phase 1: Mode & Target Discovery
 Evaluate the request and negotiate mode and format:
-1. **Mode**: Standard Bundle, Red Team Review (select persona template), or Monorepo Segmented.
+1. **Mode**: Standard Bundle, Persona-Driven Review/Handoff (select persona template), or Monorepo Segmented.
 2. **Format**: Single Markdown payload (`.md`) or Portable ZIP archive (`.zip`).
 3. **Targets**: Directories or file paths to package.
 
@@ -49,7 +58,7 @@ Present execution plan to user before running scripts:
 
 ```text
 Context Bundle Plan:
-- Mode: [Standard / Red Team (Persona) / Monorepo Segmented]
+- Mode: [Standard / Persona Review (Selected Persona) / Monorepo Segmented]
 - Format: [.md or .zip]
 - Persona Prompt: assets/templates/[selected-persona].md
 - Included Paths:
@@ -62,17 +71,17 @@ Proceed? (yes / adjust)
 
 ### Phase 3: Manifest Construction
 Generate `file-manifest.json` in temporary directory (`temp/context-bundle-[name]/`).
-For Red Team mode, `prompt.md` (containing the persona prompt) MUST be listed as the first file entry in `files`.
+For Persona-Driven mode, `prompt.md` (containing the selected persona prompt) MUST be listed as the first file entry in `files`.
 
 ```json
 {
-  "title": "Red Team Review: Auth Subsystem",
-  "description": "Adversarial security review bundle.",
+  "title": "Sub-Agent Handoff Bundle",
+  "description": "Task delegation bundle for Copilot CLI.",
   "excludes": ["**/*.png", "**/node_modules/**"],
   "files": [
     {
-      "path": "temp/context-bundle-auth/prompt.md",
-      "note": "Primary Persona Instructions"
+      "path": "temp/context-bundle-task/prompt.md",
+      "note": "Primary Persona & Handoff Instructions"
     },
     {
       "path": "plugins/dev-utils/skills/github-issue-agent/",

--- a/plugins/dev-utils/skills/context-bundler/assets/templates/agent-task-delegator.md
+++ b/plugins/dev-utils/skills/context-bundler/assets/templates/agent-task-delegator.md
@@ -1,0 +1,8 @@
+# Sub-Agent Task Handoff & Prompt Engineering Persona
+
+Act as an AI Systems Delegator and Sub-Agent Prompt Engineer. Your objective is to process the attached codebase context and generate a complete, self-contained, turnkey prompt package ready to be dispatched to a sub-agent or external LLM (such as Copilot CLI, Claude Code, or Gemini CLI).
+
+## Review Guidelines
+1. **Self-Contained Instruction Block**: Formulate explicit goal, background context, step-by-step execution rules, and output expectations.
+2. **File & Tool Boundaries**: Explicitly state which files the downstream agent is permitted to touch and which tool operations are forbidden.
+3. **Acceptance Verification Gate**: Define exact shell verification commands (pytest, linters, dry-runs) the downstream agent must pass before completing the task.

--- a/plugins/dev-utils/skills/context-bundler/assets/templates/docs-synthesis-specialist.md
+++ b/plugins/dev-utils/skills/context-bundler/assets/templates/docs-synthesis-specialist.md
@@ -1,0 +1,8 @@
+# Documentation & System Synthesis Specialist Persona
+
+Act as a Technical Writer & Knowledge Graph Synthesizer. Your objective is to ingest the attached codebase files and produce comprehensive, high-quality documentation.
+
+## Review Guidelines
+1. **Target Artifacts**: Produce clean Architecture Decision Records (ADRs), C4 PlantUML/Mermaid diagrams, README quickstart guides, or API specs.
+2. **Lossless Synthesis**: Ensure all internal configuration flags, CLI arguments, and error codes from code are accurately documented without hand-waving.
+3. **Markdown Output**: Output clean, standard GitHub Flavored Markdown ready to commit directly into `/docs` or `README.md`.

--- a/plugins/dev-utils/skills/context-bundler/assets/templates/plan-critique-reviewer.md
+++ b/plugins/dev-utils/skills/context-bundler/assets/templates/plan-critique-reviewer.md
@@ -1,0 +1,9 @@
+# Implementation Plan Critique & Hardening Persona
+
+Act as a Staff Principal Engineer and Execution Risk Architect. Your objective is to brutally stress-test the attached implementation plan and design specification before any code is written.
+
+## Review Guidelines
+1. **Identify Missing Prerequisites & Unstated Dependencies**: Flag missing environment setup, unhandled schema migrations, missing secrets, or implicit runtime assumptions.
+2. **Execution Friction & Edge Cases**: Identify where the plan relies on "magic hand-waving" or lacks test verification steps.
+3. **Phasing & Rollback Strategy**: Evaluate whether the work is broken into safe, atomic commits and if feature-flag/rollback mechanisms exist for failure recovery.
+4. **Concrete Hardened Counter-Plan**: Output a revised, step-by-step hardened implementation plan addressing every flagged risk.

--- a/plugins/dev-utils/skills/context-bundler/assets/templates/refactoring-quality-specialist.md
+++ b/plugins/dev-utils/skills/context-bundler/assets/templates/refactoring-quality-specialist.md
@@ -1,0 +1,8 @@
+# Refactoring & Code Quality Specialist Persona
+
+Act as a Senior Code Quality Specialist. Your objective is to review the attached codebase payload for refactoring opportunities, code duplication (DRY violations), overly complex methods (cyclomatic complexity), code smells, and maintenance hazards.
+
+## Review Guidelines
+1. **Smell Identification**: Highlight God objects/classes, long methods (>50 lines), primitive obsession, feature envy, and unnecessary mutability.
+2. **Simplification & Decoupling**: Suggest cleaner abstractions, extraction of helper modules, and reduction of boilerplate.
+3. **Refactored Code Diff**: Return exact refactored code blocks showing before/after improvements with zero change in external behavior.

--- a/plugins/plugin-manager/references/evolution-log.md
+++ b/plugins/plugin-manager/references/evolution-log.md
@@ -20,3 +20,7 @@
 | 2026-07-25 | Tier 1 | Failure: Skill directory '__pycache__' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
 | 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
 | 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
+| 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
+| 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
+| 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |
+| 2026-07-25 | Tier 1 | Failure: Skill directory 'red-team-bundler' in plugin 'dev-utils' is missing SKILL.md | None | None | FAILED |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -67,7 +67,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -88,42 +88,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "agy-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "analyze-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "antigravity-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:45.204613Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "brainstorming": {
       "source": "https://github.com/obra/superpowers",
@@ -144,56 +144,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "business-workflow-doc": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "claude-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:44.824639Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "co-pilot-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-15T13:53:09.074297Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "codex-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "compile-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -212,7 +212,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -233,70 +233,70 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "convert-plugin-to-apm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "create-agentic-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -308,35 +308,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "deferred": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -350,14 +350,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-07-25T14:37:56.015165Z"
+      "updatedAt": "2026-07-25T14:38:34.387021Z"
     },
     "discovery-planning": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "dispatching-parallel-agents": {
       "source": "https://github.com/obra/superpowers",
@@ -371,28 +371,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "eval-autoresearch-fit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:54:04.213659Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -488,14 +488,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "exploration-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
@@ -509,14 +509,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "exploration-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "finishing-a-development-branch": {
       "source": "https://github.com/obra/superpowers",
@@ -530,7 +530,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T18:32:57.701906Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -542,119 +542,119 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "github-issue-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:10:57.940372Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "github-issue-backlog-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:31:21.861615Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "github-issue-prioritizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:31:21.861615Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "gpt55-critical-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:10:59.858498Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "hf-download": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.901366Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "hf-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "install-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "issue-pr-lifecycle-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:33:42.454800Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "issue-worktree-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:32:08.507659Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "local-llm-bridge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "local-llm-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "loop-progress-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -668,14 +668,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "manage-marketplace": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -689,91 +689,91 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-query-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-rlm-distiller": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-wiki-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "obsidian-wiki-linter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:37:56.373918Z"
+      "updatedAt": "2026-07-25T14:38:34.691684Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -787,14 +787,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T14:43:50.703180Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "optimize-context": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-11T15:20:19.257058Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "oracle-legacy-system-analysis-business-rules": {
       "source": "oracle-legacy-system-analysis",
@@ -899,35 +899,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "os-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-environment-probe": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-26T18:04:54.227742Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-eval-lab": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -941,77 +941,77 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:55:32.819746Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-evolution-planner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-evolution-verifier": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-experiment-log": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "package-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1025,28 +1025,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "plugin-installer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-07-25T14:37:56.430032Z"
+      "updatedAt": "2026-07-25T14:38:34.742743Z"
     },
     "plugin-remover": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T14:53:48.497968Z",
-      "updatedAt": "2026-07-25T14:37:56.430032Z"
+      "updatedAt": "2026-07-25T14:38:34.742743Z"
     },
     "plugin-syncer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T15:51:44.964142Z",
-      "updatedAt": "2026-07-25T14:37:56.430032Z"
+      "updatedAt": "2026-07-25T14:38:34.742743Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -1058,14 +1058,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "prototype-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "receiving-code-review": {
       "source": "https://github.com/obra/superpowers",
@@ -1086,7 +1086,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1114,28 +1114,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.409753Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1149,28 +1149,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "self-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "self-evolution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:48.041518Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1350,21 +1350,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-31T19:06:22.971138Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "systematic-debugging": {
       "source": "https://github.com/obra/superpowers",
@@ -1378,7 +1378,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-07-25T14:37:56.156428Z"
+      "updatedAt": "2026-07-25T14:38:53.028163Z"
     },
     "test-driven-development": {
       "source": "https://github.com/obra/superpowers",
@@ -1392,7 +1392,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-07-25T14:37:55.162460Z"
+      "updatedAt": "2026-07-25T14:38:33.597857Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1413,35 +1413,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T20:54:39.722191Z",
-      "updatedAt": "2026-07-25T14:37:55.235102Z"
+      "updatedAt": "2026-07-25T14:38:33.669039Z"
     },
     "update-cli-models": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-15T14:35:39.151627Z",
-      "updatedAt": "2026-07-25T14:37:55.959753Z"
+      "updatedAt": "2026-07-25T14:38:34.334527Z"
     },
     "update-ecosystem-index": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:37:55.864271Z"
+      "updatedAt": "2026-07-25T14:38:34.252561Z"
     },
     "user-story-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "using-exploration-cycle": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.988173Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "using-git-worktrees": {
       "source": "https://github.com/obra/superpowers",
@@ -1462,42 +1462,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:37:55.377188Z"
+      "updatedAt": "2026-07-25T14:38:33.804048Z"
     },
     "verification-before-completion": {
       "source": "https://github.com/obra/superpowers",
@@ -1511,21 +1511,21 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-browser-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-domain-extractor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1539,42 +1539,42 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-slice-migrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-spec-packager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-to-speckit-superpowers": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T19:13:31.238310Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "vibe-togaf-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "visual-companion": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:37:56.301079Z"
+      "updatedAt": "2026-07-25T14:38:34.615672Z"
     },
     "writing-plans": {
       "source": "https://github.com/obra/superpowers",


### PR DESCRIPTION
Expands `context-bundler/assets/templates/` to cover 7 core context packaging persona patterns:
1. Adversarial Security Auditor (`adversarial-security-auditor.md`)
2. Structural Architecture Reviewer (`structural-architecture-reviewer.md`)
3. Compliance & Standards Reviewer (`compliance-standards-reviewer.md`)
4. Implementation Plan Critique & Stress-Tester (`plan-critique-reviewer.md`)
5. Sub-Agent Task Handoff & Prompt Delegator (`agent-task-delegator.md`)
6. Refactoring & Code Quality Specialist (`refactoring-quality-specialist.md`)
7. Documentation & System Synthesis Specialist (`docs-synthesis-specialist.md`)
