### PR TITLE
fix(dev-utils): reconcile red-team-bundler removal across metadata and symlinks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "dev-utils",
-      "description": "Unified Developer Utilities Suite — 18 skills covering ADR management, coding conventions, context bundling, Mermaid diagrams, GitHub issue logging & friction management, GitHub issue backlog bridge, issue prioritizer & Projects v2 sync, issue worktree manager, issue PR lifecycle orchestrator, HuggingFace integration, text humanization, link validation, task tracking, symlink management, and agent context hygiene.",
+      "description": "Unified Developer Utilities Suite — 17 skills covering ADR management, coding conventions, context bundling, Mermaid diagrams, GitHub issue logging & friction management, GitHub issue backlog bridge, issue prioritizer & Projects v2 sync, issue worktree manager, issue PR lifecycle orchestrator, HuggingFace integration, text humanization, link validation, task tracking, symlink management, and agent context hygiene.",
       "source": "./plugins/dev-utils",
       "strict": true,
       "category": "workflow",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,11 +220,12 @@ vector-db-cleanup, vector-db-audit, memory-management
 
 ---
 
-### dev-utils (v1.1.0) — consolidated from 9 standalone plugins
+### dev-utils (v1.4.0) — consolidated from 9 standalone plugins
 
-**Skills (12):** adr-management, coding-conventions-agent, context-bundler, convert-mermaid,
-hf-init, hf-upload, humanize, link-checker-agent, optimize-context, red-team-bundler,
-symlink-manager, task-agent
+**Skills (17):** adr-management, coding-conventions-agent, context-bundler, convert-mermaid,
+github-issue-agent, github-issue-backlog-agent, github-issue-prioritizer, hf-init, hf-upload,
+hf-download, humanize, issue-pr-lifecycle-agent, issue-worktree-agent, link-checker-agent,
+optimize-context, symlink-manager, task-agent
 
 **Do not reference:** `plugins/adr-manager`, `plugins/coding-conventions`, `plugins/context-bundler`,
 `plugins/huggingface-utils`, `plugins/link-checker`, `plugins/mermaid-to-png`,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universal Agent Plugins & Skills Ecosystem
 
-<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 12 Plugins · 133 Skills · 50 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
+<!-- ECOSYSTEM_STATS_START -->**Current Scale:** 11 Plugins · 133 Skills · 50 Sub-Agents<!-- ECOSYSTEM_STATS_END --> — a self-improving, cross-platform library of reusable AI agent
 capabilities for Claude Code, GitHub Copilot, Gemini CLI, and any compliant agent framework.
 
 > **Recent milestones:** v1.3 — Hardened SQLite control plane (May 2026) · v1.4 — MAF synthesis & hybrid runtime strategy (May 31, 2026) · v1.5 — CLI Agents major update (June 2026) · v1.6 — Coding-conventions compliance & header-freshness auditor (July 2026)

--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ Karpathy-style LLM wiki with cross-source concept synthesis. Transforms raw mark
 
 ### Group 7: Infrastructure & Utilities
 
-#### dev-utils — Developer Utilities Suite (v1.1.0)
+#### dev-utils — Developer Utilities Suite (v1.4.0)
 
 Nine standalone plugins consolidated into one. All tools are stateless and self-contained.
 
-**Skills (14):** [`adr-management`](plugins/dev-utils/skills/adr-management/SKILL.md) · [`coding-conventions-agent`](plugins/dev-utils/skills/coding-conventions-agent/SKILL.md) · [`context-bundler`](plugins/dev-utils/skills/context-bundler/SKILL.md) · [`bundle-context-full`](plugins/dev-utils/skills/bundle-context-full/SKILL.md) · [`convert-mermaid`](plugins/dev-utils/skills/convert-mermaid/SKILL.md) · [`hf-download`](plugins/dev-utils/skills/hf-download/SKILL.md) · [`hf-init`](plugins/dev-utils/skills/hf-init/SKILL.md) · [`hf-upload`](plugins/dev-utils/skills/hf-upload/SKILL.md) · [`humanize`](plugins/dev-utils/skills/humanize/SKILL.md) · [`link-checker-agent`](plugins/dev-utils/skills/link-checker-agent/SKILL.md) · [`optimize-context`](plugins/dev-utils/skills/optimize-context/SKILL.md) · [`red-team-bundler`](plugins/dev-utils/skills/red-team-bundler/SKILL.md) · [`symlink-manager`](plugins/dev-utils/skills/symlink-manager/SKILL.md) · [`task-agent`](plugins/dev-utils/skills/task-agent/SKILL.md)
+**Skills (17):** [`adr-management`](plugins/dev-utils/skills/adr-management/SKILL.md) · [`coding-conventions-agent`](plugins/dev-utils/skills/coding-conventions-agent/SKILL.md) · [`context-bundler`](plugins/dev-utils/skills/context-bundler/SKILL.md) · [`convert-mermaid`](plugins/dev-utils/skills/convert-mermaid/SKILL.md) · [`github-issue-agent`](plugins/dev-utils/skills/github-issue-agent/SKILL.md) · [`github-issue-backlog-agent`](plugins/dev-utils/skills/github-issue-backlog-agent/SKILL.md) · [`github-issue-prioritizer`](plugins/dev-utils/skills/github-issue-prioritizer/SKILL.md) · [`hf-download`](plugins/dev-utils/skills/hf-download/SKILL.md) · [`hf-init`](plugins/dev-utils/skills/hf-init/SKILL.md) · [`hf-upload`](plugins/dev-utils/skills/hf-upload/SKILL.md) · [`humanize`](plugins/dev-utils/skills/humanize/SKILL.md) · [`issue-pr-lifecycle-agent`](plugins/dev-utils/skills/issue-pr-lifecycle-agent/SKILL.md) · [`issue-worktree-agent`](plugins/dev-utils/skills/issue-worktree-agent/SKILL.md) · [`link-checker-agent`](plugins/dev-utils/skills/link-checker-agent/SKILL.md) · [`optimize-context`](plugins/dev-utils/skills/optimize-context/SKILL.md) · [`symlink-manager`](plugins/dev-utils/skills/symlink-manager/SKILL.md) · [`task-agent`](plugins/dev-utils/skills/task-agent/SKILL.md)
 
 **Agents (2):** `coding-conventions-agent` · `link-checker-agent`
 

--- a/plugins/agent-agentic-os/skills/os-evolution-verifier/SKILL.md
+++ b/plugins/agent-agentic-os/skills/os-evolution-verifier/SKILL.md
@@ -57,7 +57,7 @@ print(f'Scenario: {d[\"id\"]} — {d[\"name\"]}')
 
 If no scenarios found and no file given, report:
 > "No test scenarios found. Create scenario JSON files in `temp/os-evolution-verifier/scenarios/`
-> or run the red-team-bundler to generate them from `os-architect-agent.md`."
+> or run context-bundler (red-team mode) to generate them from `os-architect-agent.md`."
 
 ---
 

--- a/plugins/dev-utils/commands/redteam.md
+++ b/plugins/dev-utils/commands/redteam.md
@@ -5,7 +5,7 @@ argument-hint: "[threat-model or target-feature]"
 allowed-tools: Bash, Read, Write
 ---
 
-Follow the `red-team-bundler` skill workflow to prepare a security and architecture review package.
+Follow the `context-bundler` skill workflow (red-team mode, `adversarial-security-auditor.md` persona template) to prepare a security and architecture review package.
 
 ## Inputs
 

--- a/plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest-schema.json
+++ b/plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest-schema.json
@@ -1,1 +1,0 @@
-../../../../assets/resources/file-manifest-schema.json

--- a/plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest.json
+++ b/plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest.json
@@ -1,1 +1,0 @@
-../../../../assets/resources/file-manifest.json

--- a/plugins/dev-utils/skills/red-team-bundler/scripts/bundle.py
+++ b/plugins/dev-utils/skills/red-team-bundler/scripts/bundle.py
@@ -1,1 +1,0 @@
-../../../scripts/bundle.py

--- a/plugins/dev-utils/skills/red-team-bundler/scripts/bundle_zip.py
+++ b/plugins/dev-utils/skills/red-team-bundler/scripts/bundle_zip.py
@@ -1,1 +1,0 @@
-../../../scripts/bundle_zip.py

--- a/plugins/dev-utils/skills/red-team-bundler/scripts/manifest_manager.py
+++ b/plugins/dev-utils/skills/red-team-bundler/scripts/manifest_manager.py
@@ -1,1 +1,0 @@
-../../../scripts/manifest_manager.py

--- a/plugins/dev-utils/skills/red-team-bundler/scripts/path_resolver.py
+++ b/plugins/dev-utils/skills/red-team-bundler/scripts/path_resolver.py
@@ -1,1 +1,0 @@
-../../../scripts/path_resolver.py

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:23.027393Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "agent-agentic-os-agentic-os-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -67,7 +67,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "agentic-os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -88,112 +88,105 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "agy-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "analyze-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "antigravity-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:45.204613Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "audit-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "audit-plugin-l5": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "brainstorming": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
-    },
-    "bundle-context-full": {
-      "source": "https://github.com/richfrem/agent-plugins-skills",
-      "sourceType": "local",
-      "computedHash": "",
-      "installedAt": "2026-06-28T23:11:00.901366Z",
-      "updatedAt": "2026-07-25T14:34:29.341502Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "business-requirements-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "business-workflow-doc": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "claude-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "claude-project-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T18:03:44.824639Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "co-pilot-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-15T13:53:09.074297Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "codex-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "coding-conventions-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "compile-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "compliant-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -212,7 +205,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "context-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -233,70 +226,70 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:44.330740Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "convert-plugin-to-apm": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "copilot-cli-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "create-agentic-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-azure-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-command": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-docker-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-github-action": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-hook": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-legacy-command": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -308,35 +301,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-stateful-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "create-sub-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "deferred": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -350,49 +343,49 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:39.334750Z",
-      "updatedAt": "2026-07-25T14:38:34.387021Z"
+      "updatedAt": "2026-07-25T14:50:12.755682Z"
     },
     "discovery-planning": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "dispatching-parallel-agents": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "dual-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "ecosystem-authoritative-sources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "ecosystem-standards": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:36.790799Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "eval-autoresearch-fit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-30T14:54:04.213659Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "example-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -411,7 +404,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "exploration-cycle-plugin-business-rule-audit-agent": {
       "source": "exploration-cycle-plugin",
@@ -488,14 +481,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "exploration-optimizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "exploration-orchestrator": {
       "source": "exploration-cycle-plugin",
@@ -509,28 +502,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "exploration-workflow": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "finishing-a-development-branch": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "fix-plugin-paths": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T18:32:57.701906Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "flawed-skill": {
       "source": "C:\\Users\\RICHFREM\\source\\repos\\agent-plugins-skills\\plugins",
@@ -542,119 +535,119 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "github-issue-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:10:57.940372Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "github-issue-backlog-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:31:21.861615Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "github-issue-prioritizer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:31:21.861615Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "gpt55-critical-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:10:59.858498Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "hf-download": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.901366Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "hf-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "hf-upload": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:42.578134Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "humanize": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:15.472448Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "install-apm-package": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "issue-pr-lifecycle-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:33:42.454800Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "issue-worktree-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-25T14:32:08.507659Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "l5-red-team-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "learning-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "link-checker-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:03.648398Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "local-llm-bridge": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "local-llm-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.810305Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "loop-progress-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -668,14 +661,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "manage-marketplace": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:35.560640Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "markdown-to-msword-converter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -689,91 +682,91 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "mine-plugins": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "mine-skill": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "obsidian-bases-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-canvas-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-graph-traversal": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-markdown-mastery": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-query-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-rlm-distiller": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-vault-crud": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:45.486922Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-wiki-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "obsidian-wiki-linter": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.232876Z",
-      "updatedAt": "2026-07-25T14:38:34.691684Z"
+      "updatedAt": "2026-07-25T14:50:13.064079Z"
     },
     "ollama-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -787,14 +780,14 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T14:43:50.703180Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "optimize-context": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-11T15:20:19.257058Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "oracle-legacy-system-analysis-business-rules": {
       "source": "oracle-legacy-system-analysis",
@@ -899,35 +892,35 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "os-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-environment-probe": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-26T18:04:54.227742Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-eval-lab": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -941,77 +934,77 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:55:32.819746Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-evolution-planner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T21:38:48.680318Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-evolution-verifier": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-experiment-log": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-25T22:38:05.801923Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-29T23:49:59.333868Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "package-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1025,28 +1018,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "plugin-installer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:46.686677Z",
-      "updatedAt": "2026-07-25T14:38:34.742743Z"
+      "updatedAt": "2026-07-25T14:50:13.113180Z"
     },
     "plugin-remover": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T14:53:48.497968Z",
-      "updatedAt": "2026-07-25T14:38:34.742743Z"
+      "updatedAt": "2026-07-25T14:50:13.113180Z"
     },
     "plugin-syncer": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-21T15:51:44.964142Z",
-      "updatedAt": "2026-07-25T14:38:34.742743Z"
+      "updatedAt": "2026-07-25T14:50:13.113180Z"
     },
     "podcast-summarizer": {
       "source": "/Users/richardfremmerlid/Projects/agent-plugins-skills/plugins",
@@ -1058,35 +1051,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:28:01.554215Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "prototype-builder": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "receiving-code-review": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
-    },
-    "red-team-bundler": {
-      "source": "https://github.com/richfrem/agent-plugins-skills",
-      "sourceType": "local",
-      "computedHash": "",
-      "installedAt": "2026-03-28T18:14:09.690782Z",
-      "updatedAt": "2026-07-25T14:34:29.341502Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "red-team-review": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:26.539493Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "replicate-plugin": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1100,7 +1086,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "resources": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1114,28 +1100,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-17T04:45:11.409753Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "rlm-cleanup-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "rlm-curator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "rlm-distill-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "rlm-distill-ollama": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1149,28 +1135,28 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "rlm-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:48.646332Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "self-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "self-evolution": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:48.041518Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "session-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1343,56 +1329,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "subagent-driven-prototyping": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "symlink-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-31T19:06:22.971138Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "synthesize-learnings": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:29.697809Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "systematic-debugging": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "task-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:52.277759Z",
-      "updatedAt": "2026-07-25T14:38:53.028163Z"
+      "updatedAt": "2026-07-25T14:50:12.880519Z"
     },
     "test-driven-development": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "todo-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:25.406795Z",
-      "updatedAt": "2026-07-25T14:38:33.597857Z"
+      "updatedAt": "2026-07-25T14:50:11.831967Z"
     },
     "tool-inventory": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1413,119 +1399,119 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-04T20:54:39.722191Z",
-      "updatedAt": "2026-07-25T14:38:33.669039Z"
+      "updatedAt": "2026-07-25T14:50:11.896008Z"
     },
     "update-cli-models": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-07-15T14:35:39.151627Z",
-      "updatedAt": "2026-07-25T14:38:34.334527Z"
+      "updatedAt": "2026-07-25T14:50:12.710926Z"
     },
     "update-ecosystem-index": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:43:49.294214Z",
-      "updatedAt": "2026-07-25T14:38:34.252561Z"
+      "updatedAt": "2026-07-25T14:50:12.613993Z"
     },
     "user-story-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-23T19:00:41.764342Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "using-exploration-cycle": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-28T23:11:00.988173Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "using-git-worktrees": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "using-superpowers": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "vector-db-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "vector-db-cleanup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "vector-db-ingest": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "vector-db-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "vector-db-launch": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "vector-db-search": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-06-01T14:27:47.187810Z",
-      "updatedAt": "2026-07-25T14:38:33.804048Z"
+      "updatedAt": "2026-07-25T14:50:12.070719Z"
     },
     "verification-before-completion": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-27T16:11:13.243816Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "vibe-behavioral-test-capture": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-browser-audit": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-domain-extractor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-orchestrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -1539,56 +1525,56 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-slice-migrator": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T16:09:31.570265Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-spec-packager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-to-speckit-superpowers": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T19:13:31.238310Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "vibe-togaf-architect": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-22T15:50:19.636122Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "visual-companion": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-04-06T18:55:47.414076Z",
-      "updatedAt": "2026-07-25T14:38:34.615672Z"
+      "updatedAt": "2026-07-25T14:50:12.982893Z"
     },
     "writing-plans": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-05-30T18:18:00.904169Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "writing-skills": {
       "source": "https://github.com/obra/superpowers",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-03-28T18:14:07.890331Z",
-      "updatedAt": "2026-07-15T13:53:04.100411Z"
+      "updatedAt": "2026-07-25T14:50:05.470746Z"
     },
     "zip-bundling": {
       "source": "https://github.com/richfrem/agent-plugins-skills",

--- a/symlinks.json
+++ b/symlinks.json
@@ -2222,42 +2222,6 @@
       "description": ""
     },
     {
-      "src": "plugins/dev-utils/scripts/bundle.py",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/scripts/bundle.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/manifest_manager.py",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/scripts/manifest_manager.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/path_resolver.py",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/scripts/path_resolver.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/scripts/bundle_zip.py",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/scripts/bundle_zip.py",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/assets/resources/file-manifest-schema.json",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest-schema.json",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
-      "src": "plugins/dev-utils/assets/resources/file-manifest.json",
-      "dst": "plugins/dev-utils/skills/red-team-bundler/assets/resources/file-manifest.json",
-      "strategy": "symlink",
-      "description": ""
-    },
-    {
       "src": "plugins/dev-utils/references/acceptance-criteria.md",
       "dst": "plugins/dev-utils/skills/adr-management/references/acceptance-criteria.md",
       "strategy": "symlink",


### PR DESCRIPTION
## Summary
- Fixes an incomplete prior removal of the `red-team-bundler` skill (consolidated into `context-bundler` in #455/#456/#457). The skill directory kept reappearing empty because `symlinks.json` still had 6 entries pointing into it — every `symlink_manager.py restore` recreated the directory skeleton.
- Removes the stale `red-team-bundler` symlink entries and deletes the now-permanently-empty directory.
- Purges leftover `bundle-context-full` and `red-team-bundler` entries from `skills-lock.json` (the sync script doesn't auto-prune removed skills).
- Syncs `README.md`, `CLAUDE.md`, and `.claude-plugin/marketplace.json` dev-utils skill counts/lists with the actual 17-skill `plugin.yaml` (v1.4.0) — these had drifted from Phase 2 (GitHub issue lifecycle skills) as well as the bundler consolidation.
- Repoints `plugins/dev-utils/commands/redteam.md` and `os-evolution-verifier`'s fallback message at `context-bundler`'s red-team mode instead of the deleted skill.

## Not included
`plugin-sources.json` has an unrelated pre-existing uncommitted change (removes a local Windows `rlm-factory` source entry) — left out of this PR since it's out of scope; still sitting in the working tree for separate review.

## Test plan
- [x] `grep` sweep confirms no remaining `red-team-bundler`/`bundle-context-full` references in active JSON/MD/YAML files
- [x] `symlink_manager.py diagnose` — All links OK
- [x] `sync_with_inventory.py` — 10/10 plugins installed successfully
- [x] `skills-lock.json` validated as parseable JSON after edits