### PR TITLE
Fix stale plugin counts/versions in architecture.md and CLAUDE.md; cl…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,6 +77,12 @@ Upstream source monorepo for a cross-platform library of reusable AI agent plugi
 Plugins are authored here and deployed into target projects via the bridge installer.
 Individual skills must be **fully self-contained** — no runtime cross-plugin dependencies.
 
+**This working directory has no application/domain data.** If a session shows a domain-specific
+slash command or agent (e.g. `portfolio-advisor`, `tradingview`, `stock-valuation`) that isn't one
+of the plugins listed below, it's installed globally via the Claude Code marketplace and belongs
+to a *different* project — it expects files (e.g. `investment_screener/backend/data/...`) that
+don't exist here. Check `pwd` before assuming this repo owns an unfamiliar command.
+
 ### Key Commands
 ```bash
 # Install plugins into any project (recommended)
@@ -199,7 +205,7 @@ issue (`gh_issue_comment.py`) rather than opening a duplicate — see
 set in `plugin-sources.json`. Do not suggest routing work to spec-kitty or `spk-*` skills unless the user
 explicitly reinstalls it themselves.
 
-## Plugin State — Current Versions (10 plugins · 128 skills)
+## Plugin State — Current Versions (10 plugins · 139 skills)
 
 ### agent-agentic-os (v1.7.0)
 
@@ -208,10 +214,10 @@ Core improvement loop:
 os-architect → os-improvement-loop → os-eval-runner → os-eval-backport → os-experiment-log
 ```
 
-**Active skills (17):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
+**Active skills (18):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
 os-eval-backport, os-experiment-log, os-evolution-planner, os-evolution-verifier,
 os-environment-probe, os-memory-manager, os-improvement-report, os-guide, os-init,
-os-clean-locks, todo-check, optimize-agent-instructions, self-evolution
+os-clean-locks, todo-check, optimize-agent-instructions, self-evolution, gpt55-critical-auditor
 
 **Reference skills (1):** os-skill-improvement — methodology/reference only; prefer `os-improvement-loop` for active orchestration. **Do not delete.**
 
@@ -222,9 +228,9 @@ agentic-os-setup, os-health-check
 
 ---
 
-### agent-loops (v2.1.0) — OS-decoupled
+### agent-loops (v2.2.0) — OS-decoupled
 
-**6 execution primitives:** orchestrator, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
+**7 execution primitives:** orchestrator, co-pilot-loop, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
 
 **Plugin boundary:** agent-loops provides execution patterns only — no eval gate, no memory.
 os-improvement-loop delegates its inner loop to `triple-loop-learning` as the execution substrate.
@@ -233,7 +239,7 @@ Do not add OS infrastructure (evals, memory promotion, kernel calls) to agent-lo
 
 ---
 
-### cli-agents (v2.2.0) — consolidated from claude-cli, copilot-cli, gemini-cli
+### cli-agents (v2.1.0) — consolidated from claude-cli, copilot-cli, gemini-cli
 
 **Skills (14):** agent-file-synchronization, agt-security, agy-cli-agent, antigravity-project-setup,
 claude-cli-agent, claude-project-setup, codex-cli-agent, copilot-cli-agent, gemini-cli-agent,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ Upstream source monorepo for a cross-platform library of reusable AI agent plugi
 Plugins are authored here and deployed into target projects via the bridge installer.
 Individual skills must be **fully self-contained** — no runtime cross-plugin dependencies.
 
+**This working directory has no application/domain data.** If a session shows a domain-specific
+slash command or agent (e.g. `portfolio-advisor`, `tradingview`, `stock-valuation`) that isn't one
+of the plugins listed below, it's installed globally via the Claude Code marketplace and belongs
+to a *different* project — it expects files (e.g. `investment_screener/backend/data/...`) that
+don't exist here. Check `pwd` before assuming this repo owns an unfamiliar command.
+
 ### Key Commands
 ```bash
 # Install plugins into any project (recommended)
@@ -196,7 +202,7 @@ issue (`gh_issue_comment.py`) rather than opening a duplicate — see
 set in `plugin-sources.json`. Do not suggest routing work to spec-kitty or `spk-*` skills unless the user
 explicitly reinstalls it themselves.
 
-## Plugin State — Current Versions (10 plugins · 128 skills)
+## Plugin State — Current Versions (10 plugins · 139 skills)
 
 ### agent-agentic-os (v1.7.0)
 
@@ -205,10 +211,10 @@ Core improvement loop:
 os-architect → os-improvement-loop → os-eval-runner → os-eval-backport → os-experiment-log
 ```
 
-**Active skills (17):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
+**Active skills (18):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
 os-eval-backport, os-experiment-log, os-evolution-planner, os-evolution-verifier,
 os-environment-probe, os-memory-manager, os-improvement-report, os-guide, os-init,
-os-clean-locks, todo-check, optimize-agent-instructions, self-evolution
+os-clean-locks, todo-check, optimize-agent-instructions, self-evolution, gpt55-critical-auditor
 
 **Reference skills (1):** os-skill-improvement — methodology/reference only; prefer `os-improvement-loop` for active orchestration. **Do not delete.**
 
@@ -219,9 +225,9 @@ agentic-os-setup, os-health-check
 
 ---
 
-### agent-loops (v2.1.0) — OS-decoupled
+### agent-loops (v2.2.0) — OS-decoupled
 
-**6 execution primitives:** orchestrator, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
+**7 execution primitives:** orchestrator, co-pilot-loop, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
 
 **Plugin boundary:** agent-loops provides execution patterns only — no eval gate, no memory.
 os-improvement-loop delegates its inner loop to `triple-loop-learning` as the execution substrate.
@@ -230,7 +236,7 @@ Do not add OS infrastructure (evals, memory promotion, kernel calls) to agent-lo
 
 ---
 
-### cli-agents (v2.2.0) — consolidated from claude-cli, copilot-cli, gemini-cli
+### cli-agents (v2.1.0) — consolidated from claude-cli, copilot-cli, gemini-cli
 
 **Skills (14):** agent-file-synchronization, agt-security, agy-cli-agent, antigravity-project-setup,
 claude-cli-agent, claude-project-setup, codex-cli-agent, copilot-cli-agent, gemini-cli-agent,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ Upstream source monorepo for a cross-platform library of reusable AI agent plugi
 Plugins are authored here and deployed into target projects via the bridge installer.
 Individual skills must be **fully self-contained** — no runtime cross-plugin dependencies.
 
+**This working directory has no application/domain data.** If a session shows a domain-specific
+slash command or agent (e.g. `portfolio-advisor`, `tradingview`, `stock-valuation`) that isn't one
+of the plugins listed below, it's installed globally via the Claude Code marketplace and belongs
+to a *different* project — it expects files (e.g. `investment_screener/backend/data/...`) that
+don't exist here. Check `pwd` before assuming this repo owns an unfamiliar command.
+
 ### Key Commands
 ```bash
 # Install plugins into any project (recommended)
@@ -195,7 +201,7 @@ issue (`gh_issue_comment.py`) rather than opening a duplicate — see
 set in `plugin-sources.json`. Do not suggest routing work to spec-kitty or `spk-*` skills unless the user
 explicitly reinstalls it themselves.
 
-## Plugin State — Current Versions (10 plugins · 128 skills)
+## Plugin State — Current Versions (10 plugins · 139 skills)
 
 ### agent-agentic-os (v1.7.0)
 
@@ -204,10 +210,10 @@ Core improvement loop:
 os-architect → os-improvement-loop → os-eval-runner → os-eval-backport → os-experiment-log
 ```
 
-**Active skills (17):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
+**Active skills (18):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
 os-eval-backport, os-experiment-log, os-evolution-planner, os-evolution-verifier,
 os-environment-probe, os-memory-manager, os-improvement-report, os-guide, os-init,
-os-clean-locks, todo-check, optimize-agent-instructions, self-evolution
+os-clean-locks, todo-check, optimize-agent-instructions, self-evolution, gpt55-critical-auditor
 
 **Reference skills (1):** os-skill-improvement — methodology/reference only; prefer `os-improvement-loop` for active orchestration. **Do not delete.**
 
@@ -218,9 +224,9 @@ agentic-os-setup, os-health-check
 
 ---
 
-### agent-loops (v2.1.0) — OS-decoupled
+### agent-loops (v2.2.0) — OS-decoupled
 
-**6 execution primitives:** orchestrator, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
+**7 execution primitives:** orchestrator, co-pilot-loop, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
 
 **Plugin boundary:** agent-loops provides execution patterns only — no eval gate, no memory.
 os-improvement-loop delegates its inner loop to `triple-loop-learning` as the execution substrate.
@@ -229,7 +235,7 @@ Do not add OS infrastructure (evals, memory promotion, kernel calls) to agent-lo
 
 ---
 
-### cli-agents (v2.2.0) — consolidated from claude-cli, copilot-cli, gemini-cli
+### cli-agents (v2.1.0) — consolidated from claude-cli, copilot-cli, gemini-cli
 
 **Skills (14):** agent-file-synchronization, agt-security, agy-cli-agent, antigravity-project-setup,
 claude-cli-agent, claude-project-setup, codex-cli-agent, copilot-cli-agent, gemini-cli-agent,

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,6 +74,12 @@ Upstream source monorepo for a cross-platform library of reusable AI agent plugi
 Plugins are authored here and deployed into target projects via the bridge installer.
 Individual skills must be **fully self-contained** — no runtime cross-plugin dependencies.
 
+**This working directory has no application/domain data.** If a session shows a domain-specific
+slash command or agent (e.g. `portfolio-advisor`, `tradingview`, `stock-valuation`) that isn't one
+of the plugins listed below, it's installed globally via the Claude Code marketplace and belongs
+to a *different* project — it expects files (e.g. `investment_screener/backend/data/...`) that
+don't exist here. Check `pwd` before assuming this repo owns an unfamiliar command.
+
 ### Key Commands
 ```bash
 # Install plugins into any project (recommended)
@@ -196,7 +202,7 @@ issue (`gh_issue_comment.py`) rather than opening a duplicate — see
 set in `plugin-sources.json`. Do not suggest routing work to spec-kitty or `spk-*` skills unless the user
 explicitly reinstalls it themselves.
 
-## Plugin State — Current Versions (10 plugins · 128 skills)
+## Plugin State — Current Versions (10 plugins · 139 skills)
 
 ### agent-agentic-os (v1.7.0)
 
@@ -205,10 +211,10 @@ Core improvement loop:
 os-architect → os-improvement-loop → os-eval-runner → os-eval-backport → os-experiment-log
 ```
 
-**Active skills (17):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
+**Active skills (18):** os-architect, os-improvement-loop, os-eval-runner, os-eval-lab-setup,
 os-eval-backport, os-experiment-log, os-evolution-planner, os-evolution-verifier,
 os-environment-probe, os-memory-manager, os-improvement-report, os-guide, os-init,
-os-clean-locks, todo-check, optimize-agent-instructions, self-evolution
+os-clean-locks, todo-check, optimize-agent-instructions, self-evolution, gpt55-critical-auditor
 
 **Reference skills (1):** os-skill-improvement — methodology/reference only; prefer `os-improvement-loop` for active orchestration. **Do not delete.**
 
@@ -219,9 +225,9 @@ agentic-os-setup, os-health-check
 
 ---
 
-### agent-loops (v2.1.0) — OS-decoupled
+### agent-loops (v2.2.0) — OS-decoupled
 
-**6 execution primitives:** orchestrator, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
+**7 execution primitives:** orchestrator, co-pilot-loop, learning-loop, dual-loop, agent-swarm, red-team-review, triple-loop-learning
 
 **Plugin boundary:** agent-loops provides execution patterns only — no eval gate, no memory.
 os-improvement-loop delegates its inner loop to `triple-loop-learning` as the execution substrate.
@@ -230,7 +236,7 @@ Do not add OS infrastructure (evals, memory promotion, kernel calls) to agent-lo
 
 ---
 
-### cli-agents (v2.2.0) — consolidated from claude-cli, copilot-cli, gemini-cli
+### cli-agents (v2.1.0) — consolidated from claude-cli, copilot-cli, gemini-cli
 
 **Skills (14):** agent-file-synchronization, agt-security, agy-cli-agent, antigravity-project-setup,
 claude-cli-agent, claude-project-setup, codex-cli-agent, copilot-cli-agent, gemini-cli-agent,

--- a/architecture.md
+++ b/architecture.md
@@ -13,10 +13,21 @@ a bridge installer (`bootstrap.py` / `plugin_add.py`). It is not an application 
 backend — it is a **plugin ecosystem + installer**, consumed by Claude Code, GitHub Copilot, Gemini
 CLI, Antigravity, and other compliant agent frameworks.
 
-Current scale (read from `plugins/` — verify with `find plugins/*/skills -mindepth 1 -maxdepth 1 -type d | wc -l` before quoting a number elsewhere):
-- **11 plugins**
-- **128 skills** (SKILL.md definitions)
-- **46 agent definitions** (`agents/*.md` across plugins)
+**This repo's working directory contains no application/domain data.** Plugins like `portfolio-advisor`,
+`tradingview`, `stock-valuation`, and `etf-analysis` that appear in a Claude Code session's slash-command
+or agent list are installed **globally** via the Claude Code marketplace (`~/.claude/plugins/cache/`) —
+they belong to *other* projects (e.g. an investment-toolkit repo) and expect to run from *that* project's
+working directory, not this one. Invoking one of those commands while `cwd` is `agent-plugins-skills`
+will fail to find its expected files (e.g. `investment_screener/backend/data/portfolio.json`) — that's
+expected, not a bug in this repo. If a session shows an unfamiliar domain-specific command, check `pwd`
+before assuming this repo owns it.
+
+Current scale (read from `plugins/` — verify with `find plugins -name SKILL.md | wc -l` and
+`find plugins/*/agents -maxdepth 1 -name '*.md' | wc -l` before quoting a number elsewhere; excludes
+the deprecated `spec-kitty-plugin` pointer):
+- **10 plugins**
+- **139 skills** (SKILL.md definitions)
+- **51 agent definitions** (`agents/*.md` across plugins)
 
 ## 2. Project Structure
 
@@ -24,12 +35,12 @@ Current scale (read from `plugins/` — verify with `find plugins/*/skills -mind
 [Project Root]/
 ├── plugins/                        # CANONICAL SOURCE — authoritative for all skills/agents
 │   ├── agent-agentic-os/           # OS improvement loop, memory, evolution planning (19 skills)
-│   ├── agent-loops/                # OS-decoupled execution primitives (6 skills)
+│   ├── agent-loops/                # OS-decoupled execution primitives (7 skills)
 │   ├── agent-memory/               # RLM summary cache + ChromaDB vector store (13 skills)
-│   ├── agent-scaffolders/          # Plugin/skill/agent scaffolding tools (30 skills)
-│   ├── cli-agents/                 # Multi-LLM CLI dispatch (Claude/Copilot/Gemini/Agy) (12 skills)
+│   ├── agent-scaffolders/          # Plugin/skill/agent scaffolding tools (35 skills)
+│   ├── cli-agents/                 # Multi-LLM CLI dispatch (Claude/Copilot/Gemini/Agy) (14 skills)
 │   ├── dependency-management/      # pip-compile / dependency tier workflow (1 skill)
-│   ├── dev-utils/                  # ADR mgmt, symlinks, context bundling, GitHub issues, worktrees (16 skills)
+│   ├── dev-utils/                  # ADR mgmt, symlinks, context bundling, GitHub issues, worktrees (17 skills)
 │   ├── exploration-cycle-plugin/   # Business discovery workflow + SQLite control plane (20 skills)
 │   ├── obsidian-wiki-engine/       # Karpathy-style LLM wiki over the codebase (10 skills)
 │   ├── plugin-manager/             # Install/remove/sync plugins into target projects (3 skills)
@@ -92,7 +103,7 @@ os-eval-backport → os-experiment-log`. Also owns memory management (`os-memory
 planning (`os-evolution-planner`/`os-evolution-verifier`), and setup (`os-init`,
 `agentic-os-setup` agent).
 
-### 4.3. Plugin: agent-loops (v2.1.0)
+### 4.3. Plugin: agent-loops (v2.2.0)
 Six OS-decoupled execution primitives (orchestrator, learning-loop, dual-loop, agent-swarm,
 red-team-review, triple-loop-learning). Provides execution patterns only — no eval gate, no memory;
 `os-improvement-loop` delegates its inner loop to `triple-loop-learning` as substrate.
@@ -103,17 +114,18 @@ plugins: RLM (dense-summary keyword cache, O(1) lookup, zero deps) and vector-db
 embeddings). Can run standalone or combined as part of a "Super-RAG" stack with
 `obsidian-wiki-engine`.
 
-### 4.5. Plugin: agent-scaffolders (30 skills)
+### 4.5. Plugin: agent-scaffolders (v2.1.0, 35 skills)
 Tooling for creating and validating new ecosystem components: `create-plugin`, `create-skill`,
 `create-sub-agent`, `audit-plugin`, plus APM package conversion, marketplace management, and
 ecosystem-index maintenance.
 
-### 4.6. Plugin: cli-agents (v1.1.0)
+### 4.6. Plugin: cli-agents (v2.1.0)
 Multi-LLM task router (`run_agent.py`) consolidated from claude-cli/copilot-cli/gemini-cli.
-6 backends, `--isolated` security contract, 11 expert-persona sub-agents (architect-review,
-security-auditor, red-team-reviewer, etc.). Model selection driven by
-`references/copilot-models.json` cost tiers. Gemini CLI consumer access ends June 18, 2026 —
-`agy-cli-agent` is the forward path for frontier models.
+6 backends, `--isolated` security contract, 12 expert-persona sub-agents (architect-review,
+security-auditor, tdd-contract-reviewer, red-team-reviewer, etc.) — the first three form the
+"Graph Planning Phase 1 Fan-Out Trio" per `graph-planning-superpowers-policy.md`. Model selection
+driven by `references/copilot-models.json` cost tiers. Gemini CLI consumer access ended June 18,
+2026 — `agy-cli-agent` is the forward path for frontier models.
 
 ### 4.7. Plugin: exploration-cycle-plugin (20 skills) — security-sensitive
 Business discovery workflow (Path 1: pre-build discovery; Path 2: vibe-coded-prototype
@@ -127,9 +139,10 @@ first — no casual convenience bypasses to the authorization gate or path enfor
 Karpathy-style LLM wiki generation over the codebase; standalone or combined with agent-memory as
 the third leg of the Super-RAG stack.
 
-### 4.9. Plugin: dev-utils (v1.1.0, 14 skills)
+### 4.9. Plugin: dev-utils (v1.4.0, 17 skills)
 Consolidated from 9 former standalone plugins: ADR management, coding-conventions enforcement,
-context bundling, mermaid conversion, HuggingFace init/upload, humanize, link-checking, context
+context bundling (now includes a Multi-Persona Fan-Out mode for parallel adversarial plan
+review), mermaid conversion, HuggingFace init/upload, humanize, link-checking, context
 optimization, `symlink-manager` (the only sanctioned way to create symlinks in this repo),
 task-agent.
 
@@ -159,10 +172,20 @@ natively-managed upstream `Priivacy-ai/spec-kitty` package (installed separately
 | 007 | MAF (Microsoft Agent Framework) is an optional certified runtime adapter, never the primary orchestration kernel — `.md` manifests remain the portable source of truth across Claude Code / Copilot CLI / Gemini CLI / MAF |
 
 Full rule text (rationale, examples, enforcement detail) lives in `.agent/rules/` — CLAUDE.md only
-carries the summary. Key files: `coding-conventions.md`, `dependency-management.md`,
-`plugin-architecture-policy.md`, `self-evolution-policy.md`, `symlink-cross-platform.md`,
-`test-driven-development.md`, `destructive-action-guard.md`, `git-operations.md`,
-`skill-deletion-guard.md`.
+carries the summary. Full current set: `graph-planning-superpowers-policy.md` (the plan/review/
+execution lifecycle — native Plan Mode sandboxing, context-bundler adversarial fan-out capped at
+2-3 rounds, worktree-isolated Superpowers TDD, multi-stage verification), `coding-conventions.md`,
+`dependency-management.md`, `plugin-architecture-policy.md`, `self-evolution-policy.md`,
+`symlink-cross-platform.md`, `test-driven-development.md`, `destructive-action-guard.md`,
+`git-operations.md`, `skill-deletion-guard.md`, `github-issue-logging-policy.md`,
+`pre-push-audit.md`, `worktree-subagent-leak-detection.md` (a dispatched subagent's writes
+leaking outside its assigned worktree — renamed 2026-08-18, formerly `worktree-subagent-isolation.md`),
+`worktree-lifecycle-management.md` (the full worktree lifecycle — state vocabulary for
+written/committed/pushed/merged/ref-updated/checked-out-on-disk, added the same day as a
+companion to the leak-detection rule, not a replacement for it),
+`adversarial-reasoning-before-agreement-rule.md`.
+Every file in `.agent/rules/` has a matching master under some `plugins/*/rules/` — verify with
+`python3 plugins/cli-agents/scripts/sync_instruction_files.py --check-rules`.
 
 ## 6. Skill & Plugin Authoring Standards
 
@@ -218,6 +241,10 @@ setuptools artifact (from `pip install -e .` / packaging), not an application bu
 - **v1.4** — MAF synthesis: hybrid architecture, MAF adopted as certified optional adapter (ADR-007),
   not a kernel replacement.
 - **v1.5** — cli-agents promoted to a full multi-LLM task router with adversarial agent personas.
+- **v1.6** — Graph Planning + Superpowers execution discipline (`graph-planning-superpowers-policy.md`,
+  replacing the retired `spec-driven-development-policy.md`): native Plan Mode sandboxing wired into
+  `os-architect`/`os-evolution-planner`, `context-bundler`'s Multi-Persona Fan-Out Mode, the
+  `tdd-contract-reviewer` persona, and `red-team-review`'s 2-3 round convergence cap.
 
 ## 12. Glossary
 


### PR DESCRIPTION
…arify marketplace plugins aren't part of this repo

architecture.md:
- Fixed stale counts (11->10 plugins, 128->139 skills, 46->51 agents) and per-plugin skill counts in the tree diagram
- Fixed version numbers: agent-loops v2.1.0->2.2.0, cli-agents v1.1.0->2.1.0, agent-scaffolders version added (v2.1.0), dev-utils v1.1.0->1.4.0
- Added all rule files to the SS 5 list, including graph-planning-superpowers-policy.md and the worktree-subagent-leak-detection.md / worktree-lifecycle-management.md rename+split from #478
- Added a v1.6 changelog entry for the Graph Planning + Superpowers policy work

CLAUDE.md (propagated to GEMINI.md / copilot-instructions.md / AGENTS.md via sync_instruction_files.py):
- Fixed a real bug: agent-loops and cli-agents version numbers were swapped
- Fixed the top-level skill count (128->139) and agent-agentic-os's active-skills list, which was missing gpt55-critical-auditor (17 listed vs 19 actual)
- Fixed agent-loops' primitive count (6->7, missing co-pilot-loop)
- Added a note clarifying that domain-specific marketplace plugins (portfolio-advisor, tradingview, etc.) installed globally are NOT part of this repo and expect a different project's working directory -- addresses a real session mixup this exact issue caused

Docs-only change (no plugin skill/script/reference content touched) -- no plugin reinstall required per the CLAUDE.md reinstall-rule exemption. sync_instruction_files.py --check-rules confirms zero drift across all 15 .agent/rules/ <-> plugins/*/rules/ pairs.