### PR TITLE
feat(rules): enforce turn-by-turn proactive Pre-Completion Gate emission

### DIFF
--- a/plugins/agent-agentic-os/rules/self-evolution-policy.md
+++ b/plugins/agent-agentic-os/rules/self-evolution-policy.md
@@ -115,7 +115,10 @@ If an existing repo capability is intended for the task, the agent must use it. 
 
 ### Pre-Completion Self-Evolution Gate
 
-Before claiming a task is complete, output this block verbatim:
+> [!IMPORTANT]
+> **Turn-by-Turn Mandatory Protocol**: The PRE-COMPLETION GATE is NOT an optional end-of-session ceremony. On EVERY turn where the agent performs code modifications, test execution, or hands completed work/review findings back to the user, the agent MUST proactively output the verbatim PRE-COMPLETION GATE receipt before yielding control. Omitting this block or waiting for the user to ask is a protocol violation.
+
+Before claiming ANY task or iterative turn is complete, output this block verbatim:
 
 ```
 PRE-COMPLETION GATE:
@@ -128,7 +131,7 @@ If any YES: action taken -> FIX / MAP_DEBT / ESCALATE
   [Physical Disk Write Verified: wiki/<playbook>.md (if resolved) or references/map-debt.md]
 ```
 
-The block must be emitted as literal text, not silent introspection. **The task is not complete until every YES is backed by a verified physical disk write**:
+The block must be emitted as literal text, not silent introspection. **The turn is not complete until every YES is backed by a verified physical disk write**:
 - If fixed/resolved: An active playbook in `wiki/` (or updated rules/docs) AND a `Status: RESOLVED` row in `references/map-debt.md`.
 - If deferred: A `Status: OPEN` row in `references/map-debt.md`.
 

--- a/plugins/dev-utils/rules/graph-planning-superpowers-policy.md
+++ b/plugins/dev-utils/rules/graph-planning-superpowers-policy.md
@@ -65,6 +65,7 @@ Verification is defense-in-depth and cannot rely solely on self-reported agent s
 1. **Deterministic Local Pass:** 100% green pass on test runners, static linters, and type checkers (`evaluate.py` / `npm test` / `cargo test`).
 2. **Structural Workspace Verification:** Clean git worktree merge and branch teardown via host tools.
 3. **Out-of-Band Context Alignment:** Use `context-bundler` to bundle modified files and git diffs for external alignment verification (e.g. Gemini UI inspection) prior to production deployment.
+4. **Autonomous Receipt Emission:** The agent must proactively emit the verbatim `PRE-COMPLETION GATE` receipt and log resolved/open map debt to disk at the conclusion of every verification cycle without waiting for user prompts.
 
 ---
 


### PR DESCRIPTION
## Summary
Updates `self-evolution-policy.md` and `graph-planning-superpowers-policy.md` across the plugin ecosystem:
- Mandates that the `PRE-COMPLETION GATE` receipt and physical `map-debt.md` writes must be emitted proactively on **every turn** where an agent modifies code, runs tests, or hands work/review findings back to the user/reviewer.
- Explicitly defines waiting for user prompting as a protocol violation.