### PR TITLE
chore: sync worktree rules, multi-tool contribution policy, and gitignore

### DIFF
--- a/.agent/rules/worktree-lifecycle-management.md
+++ b/.agent/rules/worktree-lifecycle-management.md
@@ -69,6 +69,16 @@ Worktree-related changes frequently suffer from ambiguity when multiple git stat
 7. **When multiple worktrees exist, or worktree work spans several turns, restate the
    current state of every open worktree at the start of any status report** -- don't make
    the user re-derive it from scattered messages.
+8. **Mandatory Post-Implementation Review Stage Gate (`WORKTREE_REVIEW`)**: Once code development
+   and automated tests pass inside a worktree, AI agents MUST NEVER autonomously push to origin
+   or open a PR. The agent MUST transition the task in `context/control_plane.db` to `WORKTREE_REVIEW`,
+   present the diff and summary to the human user, and provide the user the explicit choice between:
+   - (A) Running multi-agent adversarial code review (`MULTI_AGENT_CODE_REVIEW`) across independent model perspectives, or
+   - (B) Authorizing direct `git push` and PR creation for human review.
+9. **Zero Autonomous Push Invariant**: Pushing code to origin without passing through the post-implementation
+   review gate and receiving user authorization is an operational violation. Pre-push hooks and
+   `agent_control.py update-worktree` will reject any attempt to mark a worktree as `pushed_to_origin`
+   unless the task has transitioned through `WORKTREE_REVIEW`.
 
 ## Where This Applies
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2141,3 +2141,11 @@ globs: ["requirements*.txt", "requirements*.in", "Dockerfile", "pyproject.toml"]
 7. **Symlink Resolution** — installers resolve symlinks to physical copies in `.agents/`; installed skills must be fully self-contained.
 8. **Agent Orchestration** — cross-plugin coordination uses skill delegation via the prompt loop, not direct script execution.
 
+
+
+## Plugin & Skill Maintenance Policy
+- Check `context/plugin-config.json` for this repository's configured contribution mode:
+  1. `fork-and-pr`: Test fix locally, commit to feature branch in cloned upstream repo, and submit PR to `richfrem/agent-plugins-skills`.
+  2. `local-patch-and-issue`: Apply immediate fix directly in `.agents/skills/` and log an issue in `richfrem/agent-plugins-skills` with reproduction details.
+  3. `domain-override`: Keep upstream shared skills unmodified; put project customizations in `.agent/rules/local-*` or local `plugins/`.
+- Never make silent undocumented edits to shared skills without either opening an upstream PR or logging an issue.

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ context/*.db-wal
 context/*.db-shm
 context/*.jsonl
 context/os-state.json
+context/plugin-config.json
 context/bundles/
 
 # Added by Spec Kitty CLI (auto-managed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2138,3 +2138,11 @@ globs: ["requirements*.txt", "requirements*.in", "Dockerfile", "pyproject.toml"]
 7. **Symlink Resolution** — installers resolve symlinks to physical copies in `.agents/`; installed skills must be fully self-contained.
 8. **Agent Orchestration** — cross-plugin coordination uses skill delegation via the prompt loop, not direct script execution.
 
+
+
+## Plugin & Skill Maintenance Policy
+- Check `context/plugin-config.json` for this repository's configured contribution mode:
+  1. `fork-and-pr`: Test fix locally, commit to feature branch in cloned upstream repo, and submit PR to `richfrem/agent-plugins-skills`.
+  2. `local-patch-and-issue`: Apply immediate fix directly in `.agents/skills/` and log an issue in `richfrem/agent-plugins-skills` with reproduction details.
+  3. `domain-override`: Keep upstream shared skills unmodified; put project customizations in `.agent/rules/local-*` or local `plugins/`.
+- Never make silent undocumented edits to shared skills without either opening an upstream PR or logging an issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2138,3 +2138,11 @@ globs: ["requirements*.txt", "requirements*.in", "Dockerfile", "pyproject.toml"]
 7. **Symlink Resolution** — installers resolve symlinks to physical copies in `.agents/`; installed skills must be fully self-contained.
 8. **Agent Orchestration** — cross-plugin coordination uses skill delegation via the prompt loop, not direct script execution.
 
+
+
+## Plugin & Skill Maintenance Policy
+- Check `context/plugin-config.json` for this repository's configured contribution mode:
+  1. `fork-and-pr`: Test fix locally, commit to feature branch in cloned upstream repo, and submit PR to `richfrem/agent-plugins-skills`.
+  2. `local-patch-and-issue`: Apply immediate fix directly in `.agents/skills/` and log an issue in `richfrem/agent-plugins-skills` with reproduction details.
+  3. `domain-override`: Keep upstream shared skills unmodified; put project customizations in `.agent/rules/local-*` or local `plugins/`.
+- Never make silent undocumented edits to shared skills without either opening an upstream PR or logging an issue.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2138,6 +2138,15 @@ globs: ["requirements*.txt", "requirements*.in", "Dockerfile", "pyproject.toml"]
 7. **Symlink Resolution** — installers resolve symlinks to physical copies in `.agents/`; installed skills must be fully self-contained.
 8. **Agent Orchestration** — cross-plugin coordination uses skill delegation via the prompt loop, not direct script execution.
 
+
+
+## Plugin & Skill Maintenance Policy
+- Check `context/plugin-config.json` for this repository's configured contribution mode:
+  1. `fork-and-pr`: Test fix locally, commit to feature branch in cloned upstream repo, and submit PR to `richfrem/agent-plugins-skills`.
+  2. `local-patch-and-issue`: Apply immediate fix directly in `.agents/skills/` and log an issue in `richfrem/agent-plugins-skills` with reproduction details.
+  3. `domain-override`: Keep upstream shared skills unmodified; put project customizations in `.agent/rules/local-*` or local `plugins/`.
+- Never make silent undocumented edits to shared skills without either opening an upstream PR or logging an issue.
+
 ## Gemini CLI Tool Mapping
 
 | Claude Code | Gemini CLI equivalent |


### PR DESCRIPTION
## Summary
- Syncs `.agent/rules/worktree-lifecycle-management.md` with rules 8 & 9 (post-implementation review stage gate and zero autonomous push).
- Syncs multi-tool instructions (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.github/copilot-instructions.md`) with standard Plugin & Skill Maintenance Policy.
- Adds `context/plugin-config.json` to `.gitignore` to keep runtime configuration untracked.