### PR TITLE
Fix mermaid unclosed fence + polish edge labels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ stateDiagram-v2
     DRAFT_PLAN --> MULTI_AGENT_REVIEW : you say yes to AI plan review
     DRAFT_PLAN --> AWAITING_APPROVAL : you say no — skip straight ahead
     MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
-    AWAITING_APPROVAL --> APPROVED : you say "Proceed" / "Go"<br>(mandatory gate)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(mandatory gate)
     APPROVED --> IN_WORKTREE
     IN_WORKTREE --> WORKTREE_REVIEW : implementation + tests done
     WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : you say yes to AI code review
@@ -184,10 +184,10 @@ stateDiagram-v2
     DRAFT_PLAN --> INTERVIEW : needs more questions
     PLAN_REVIEW --> INTERVIEW : needs more questions
 
-    DRAFT_PLAN --> MULTI_AGENT_REVIEW : "Want a second AI opinion<br>on this plan first?" — yes
-    PLAN_REVIEW --> MULTI_AGENT_REVIEW : "Want a second AI opinion<br>on this plan first?" — yes
-    DRAFT_PLAN --> AWAITING_APPROVAL : "...or proceed straight<br>to your approval?" — yes<br>(skip recorded, never silent)
-    PLAN_REVIEW --> AWAITING_APPROVAL : "...or proceed straight<br>to your approval?" — yes<br>(skip recorded, never silent)
+    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
+    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
+    DRAFT_PLAN --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
+    PLAN_REVIEW --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
     DRAFT_PLAN --> ESCALATED
     PLAN_REVIEW --> ESCALATED
 
@@ -196,7 +196,7 @@ stateDiagram-v2
     MULTI_AGENT_REVIEW --> PLAN_REVIEW : reviewer requested changes
     MULTI_AGENT_REVIEW --> ESCALATED
 
-    AWAITING_APPROVAL --> APPROVED : you say "Proceed" / "Go"<br>(this step can never be skipped)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(this step can never be skipped)
     AWAITING_APPROVAL --> DRAFT_PLAN : needs more work
     AWAITING_APPROVAL --> PLAN_REVIEW : needs more work
     AWAITING_APPROVAL --> MULTI_AGENT_REVIEW : needs more work
@@ -210,8 +210,8 @@ stateDiagram-v2
     IN_WORKTREE --> ROLLED_BACK
     IN_WORKTREE --> ESCALATED
 
-    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : "Want a second AI review<br>of this code?" — yes
-    WORKTREE_REVIEW --> VERIFY_EXIT : "...or proceed straight<br>to verification?" — yes<br>(skip recorded, never silent)
+    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br>of this code? — yes
+    WORKTREE_REVIEW --> VERIFY_EXIT : ...or proceed straight<br>to verification? — yes<br>(skip recorded, never silent)
     WORKTREE_REVIEW --> IN_WORKTREE : more changes needed
     WORKTREE_REVIEW --> ROLLED_BACK
     WORKTREE_REVIEW --> ESCALATED

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ stateDiagram-v2
     DRAFT_PLAN --> MULTI_AGENT_REVIEW : you say yes to AI plan review
     DRAFT_PLAN --> AWAITING_APPROVAL : you say no — skip straight ahead
     MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
-    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(mandatory gate)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br/>(mandatory gate)
     APPROVED --> IN_WORKTREE
     IN_WORKTREE --> WORKTREE_REVIEW : implementation + tests done
     WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : you say yes to AI code review
@@ -176,8 +176,8 @@ stateDiagram-v2
     INTAKE --> PLAN_REVIEW : skip straight to planning
     INTAKE --> ESCALATED
 
-    INTERVIEW --> DRAFT_PLAN : plan/questions complete<br>(or explicit skip, recorded)
-    INTERVIEW --> PLAN_REVIEW : plan/questions complete<br>(or explicit skip, recorded)
+    INTERVIEW --> DRAFT_PLAN : plan/questions complete<br/>(or explicit skip, recorded)
+    INTERVIEW --> PLAN_REVIEW : plan/questions complete<br/>(or explicit skip, recorded)
     INTERVIEW --> ESCALATED
 
     DRAFT_PLAN --> PLAN_REVIEW : same step, either path
@@ -185,19 +185,19 @@ stateDiagram-v2
     DRAFT_PLAN --> INTERVIEW : needs more questions
     PLAN_REVIEW --> INTERVIEW : needs more questions
 
-    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
-    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
-    DRAFT_PLAN --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
-    PLAN_REVIEW --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
+    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br/>on this plan first? Yes
+    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br/>on this plan first? Yes
+    DRAFT_PLAN --> AWAITING_APPROVAL : Proceed straight<br/>to your approval? Yes<br/>(skip recorded, never silent)
+    PLAN_REVIEW --> AWAITING_APPROVAL : Proceed straight<br/>to your approval? Yes<br/>(skip recorded, never silent)
     DRAFT_PLAN --> ESCALATED
     PLAN_REVIEW --> ESCALATED
 
-    MULTI_AGENT_REVIEW --> AWAITING_APPROVAL
+    MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
     MULTI_AGENT_REVIEW --> DRAFT_PLAN : reviewer requested changes
     MULTI_AGENT_REVIEW --> PLAN_REVIEW : reviewer requested changes
     MULTI_AGENT_REVIEW --> ESCALATED
 
-    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(this step can never be skipped)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br/>(this step can never be skipped)
     AWAITING_APPROVAL --> DRAFT_PLAN : needs more work
     AWAITING_APPROVAL --> PLAN_REVIEW : needs more work
     AWAITING_APPROVAL --> MULTI_AGENT_REVIEW : needs more work
@@ -211,8 +211,8 @@ stateDiagram-v2
     IN_WORKTREE --> ROLLED_BACK
     IN_WORKTREE --> ESCALATED
 
-    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br>of this code? — yes
-    WORKTREE_REVIEW --> VERIFY_EXIT : ...or proceed straight<br>to verification? — yes<br>(skip recorded, never silent)
+    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br/>of this code? Yes
+    WORKTREE_REVIEW --> VERIFY_EXIT : Proceed straight<br/>to verification? Yes<br/>(skip recorded, never silent)
     WORKTREE_REVIEW --> IN_WORKTREE : more changes needed
     WORKTREE_REVIEW --> ROLLED_BACK
     WORKTREE_REVIEW --> ESCALATED

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ stateDiagram-v2
     WORKTREE_REVIEW --> VERIFY_EXIT : you say no — skip straight ahead
     MULTI_AGENT_CODE_REVIEW --> VERIFY_EXIT : review passed
     VERIFY_EXIT --> DONE : all checks passed
-    DONE --> [*]```
+    DONE --> [*]
+```
 
 Source: [`docs/diagrams/control-plane-pipeline-happy-path.mermaid`](docs/diagrams/control-plane-pipeline-happy-path.mermaid).
 

--- a/docs/diagrams/control-plane-pipeline-happy-path.mermaid
+++ b/docs/diagrams/control-plane-pipeline-happy-path.mermaid
@@ -17,7 +17,7 @@ stateDiagram-v2
     DRAFT_PLAN --> MULTI_AGENT_REVIEW : you say yes to AI plan review
     DRAFT_PLAN --> AWAITING_APPROVAL : you say no — skip straight ahead
     MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
-    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(mandatory gate)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br/>(mandatory gate)
     APPROVED --> IN_WORKTREE
     IN_WORKTREE --> WORKTREE_REVIEW : implementation + tests done
     WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : you say yes to AI code review

--- a/docs/diagrams/control-plane-pipeline-happy-path.mermaid
+++ b/docs/diagrams/control-plane-pipeline-happy-path.mermaid
@@ -17,7 +17,7 @@ stateDiagram-v2
     DRAFT_PLAN --> MULTI_AGENT_REVIEW : you say yes to AI plan review
     DRAFT_PLAN --> AWAITING_APPROVAL : you say no — skip straight ahead
     MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
-    AWAITING_APPROVAL --> APPROVED : you say "Proceed" / "Go"<br>(mandatory gate)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(mandatory gate)
     APPROVED --> IN_WORKTREE
     IN_WORKTREE --> WORKTREE_REVIEW : implementation + tests done
     WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : you say yes to AI code review

--- a/docs/diagrams/control-plane-pipeline.mermaid
+++ b/docs/diagrams/control-plane-pipeline.mermaid
@@ -29,10 +29,10 @@ stateDiagram-v2
     DRAFT_PLAN --> INTERVIEW : needs more questions
     PLAN_REVIEW --> INTERVIEW : needs more questions
 
-    DRAFT_PLAN --> MULTI_AGENT_REVIEW : "Want a second AI opinion<br>on this plan first?" — yes
-    PLAN_REVIEW --> MULTI_AGENT_REVIEW : "Want a second AI opinion<br>on this plan first?" — yes
-    DRAFT_PLAN --> AWAITING_APPROVAL : "...or proceed straight<br>to your approval?" — yes<br>(skip recorded, never silent)
-    PLAN_REVIEW --> AWAITING_APPROVAL : "...or proceed straight<br>to your approval?" — yes<br>(skip recorded, never silent)
+    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
+    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
+    DRAFT_PLAN --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
+    PLAN_REVIEW --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
     DRAFT_PLAN --> ESCALATED
     PLAN_REVIEW --> ESCALATED
 
@@ -41,7 +41,7 @@ stateDiagram-v2
     MULTI_AGENT_REVIEW --> PLAN_REVIEW : reviewer requested changes
     MULTI_AGENT_REVIEW --> ESCALATED
 
-    AWAITING_APPROVAL --> APPROVED : you say "Proceed" / "Go"<br>(this step can never be skipped)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(this step can never be skipped)
     AWAITING_APPROVAL --> DRAFT_PLAN : needs more work
     AWAITING_APPROVAL --> PLAN_REVIEW : needs more work
     AWAITING_APPROVAL --> MULTI_AGENT_REVIEW : needs more work
@@ -55,8 +55,8 @@ stateDiagram-v2
     IN_WORKTREE --> ROLLED_BACK
     IN_WORKTREE --> ESCALATED
 
-    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : "Want a second AI review<br>of this code?" — yes
-    WORKTREE_REVIEW --> VERIFY_EXIT : "...or proceed straight<br>to verification?" — yes<br>(skip recorded, never silent)
+    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br>of this code? — yes
+    WORKTREE_REVIEW --> VERIFY_EXIT : ...or proceed straight<br>to verification? — yes<br>(skip recorded, never silent)
     WORKTREE_REVIEW --> IN_WORKTREE : more changes needed
     WORKTREE_REVIEW --> ROLLED_BACK
     WORKTREE_REVIEW --> ESCALATED

--- a/docs/diagrams/control-plane-pipeline.mermaid
+++ b/docs/diagrams/control-plane-pipeline.mermaid
@@ -20,8 +20,8 @@ stateDiagram-v2
     INTAKE --> PLAN_REVIEW : skip straight to planning
     INTAKE --> ESCALATED
 
-    INTERVIEW --> DRAFT_PLAN : plan/questions complete<br>(or explicit skip, recorded)
-    INTERVIEW --> PLAN_REVIEW : plan/questions complete<br>(or explicit skip, recorded)
+    INTERVIEW --> DRAFT_PLAN : plan/questions complete<br/>(or explicit skip, recorded)
+    INTERVIEW --> PLAN_REVIEW : plan/questions complete<br/>(or explicit skip, recorded)
     INTERVIEW --> ESCALATED
 
     DRAFT_PLAN --> PLAN_REVIEW : same step, either path
@@ -29,19 +29,19 @@ stateDiagram-v2
     DRAFT_PLAN --> INTERVIEW : needs more questions
     PLAN_REVIEW --> INTERVIEW : needs more questions
 
-    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
-    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br>on this plan first? — yes
-    DRAFT_PLAN --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
-    PLAN_REVIEW --> AWAITING_APPROVAL : ...or proceed straight<br>to your approval? — yes<br>(skip recorded, never silent)
+    DRAFT_PLAN --> MULTI_AGENT_REVIEW : Want a second AI opinion<br/>on this plan first? Yes
+    PLAN_REVIEW --> MULTI_AGENT_REVIEW : Want a second AI opinion<br/>on this plan first? Yes
+    DRAFT_PLAN --> AWAITING_APPROVAL : Proceed straight<br/>to your approval? Yes<br/>(skip recorded, never silent)
+    PLAN_REVIEW --> AWAITING_APPROVAL : Proceed straight<br/>to your approval? Yes<br/>(skip recorded, never silent)
     DRAFT_PLAN --> ESCALATED
     PLAN_REVIEW --> ESCALATED
 
-    MULTI_AGENT_REVIEW --> AWAITING_APPROVAL
+    MULTI_AGENT_REVIEW --> AWAITING_APPROVAL : review complete
     MULTI_AGENT_REVIEW --> DRAFT_PLAN : reviewer requested changes
     MULTI_AGENT_REVIEW --> PLAN_REVIEW : reviewer requested changes
     MULTI_AGENT_REVIEW --> ESCALATED
 
-    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br>(this step can never be skipped)
+    AWAITING_APPROVAL --> APPROVED : you say Proceed / Go<br/>(this step can never be skipped)
     AWAITING_APPROVAL --> DRAFT_PLAN : needs more work
     AWAITING_APPROVAL --> PLAN_REVIEW : needs more work
     AWAITING_APPROVAL --> MULTI_AGENT_REVIEW : needs more work
@@ -55,8 +55,8 @@ stateDiagram-v2
     IN_WORKTREE --> ROLLED_BACK
     IN_WORKTREE --> ESCALATED
 
-    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br>of this code? — yes
-    WORKTREE_REVIEW --> VERIFY_EXIT : ...or proceed straight<br>to verification? — yes<br>(skip recorded, never silent)
+    WORKTREE_REVIEW --> MULTI_AGENT_CODE_REVIEW : Want a second AI review<br/>of this code? Yes
+    WORKTREE_REVIEW --> VERIFY_EXIT : Proceed straight<br/>to verification? Yes<br/>(skip recorded, never silent)
     WORKTREE_REVIEW --> IN_WORKTREE : more changes needed
     WORKTREE_REVIEW --> ROLLED_BACK
     WORKTREE_REVIEW --> ESCALATED


### PR DESCRIPTION
## Summary
Follow-up to #527, which merged only the first commit (quote-label fix) before this branch's remaining fixes were pushed. Merging main into this branch and taking this branch's version for the affected files (strict superset of what already merged) to bring in:

- **The actual root cause of the reported parse error**: `docs/diagrams/control-plane-pipeline-happy-path.mermaid`'s closing fence was glued to `DONE --> [*]` with no line break (`DONE --> [*]\`\`\``), so per CommonMark the first mermaid fence never closed — it silently swallowed the second diagram's entire source as invalid content. This is what actually produced `Parse error on line 32 ... got 'INVALID'`.
- Cosmetic polish: `<br>` → `<br/>`, dropped stray embedded quotes/em-dashes in edge labels, added a missing edge label for consistency.

## Test plan
- [x] `mmdc -i docs/diagrams/control-plane-pipeline.mermaid` — exits 0
- [x] `mmdc -i docs/diagrams/control-plane-pipeline-happy-path.mermaid` — exits 0
- [x] Extracted both README.md fenced mermaid blocks programmatically and rendered each with `mmdc` — both exit 0
- [x] Confirmed `origin/main`'s current README still has the unclosed-fence bug (grep for `DONE --> [*]\`\`\``) before this PR