### PR TITLE
docs: expand SQLite trigger gotchas wiki entry with #552's Gotcha 4

### DIFF
--- a/wiki/decisions/sqlite-trigger-enforcement-gotchas.md
+++ b/wiki/decisions/sqlite-trigger-enforcement-gotchas.md
@@ -48,15 +48,36 @@ explicitly `DROP TRIGGER IF EXISTS` before the rename step and recreate every tr
 after the table swap completes; never assume `CREATE TRIGGER IF NOT EXISTS` inside the
 fresh schema DDL is sufficient during a rename-based migration.
 
-## Related, but not itself a new gotcha (documented separately)
+## Gotcha 4: `conn.executescript()` silently commits any open transaction — and its
+statements' own embedded `PRAGMA`s can silently override the caller's connection settings
+
+**Status:** CONFIRMED — fixed via GitHub Issue #552, 2026-09-07.
 
 `conn.executescript()` in Python's `sqlite3` module implicitly commits any open
-transaction before running — meaning a `BEGIN IMMEDIATE` opened before an
-`executescript()` call provides no real atomicity for anything after that call. This
-predates issue #523 (found in `_rebuild_schema_transactional()`, which dates to an earlier
-extraction) and is tracked separately as GitHub Issue #552 — included here only as a
-pointer, since anyone reading this file while building on the rename-migration pattern in
-Gotcha 3 will run into it.
+transaction before running (documented CPython behavior) — a `BEGIN IMMEDIATE` opened
+before an `executescript()` call provides no real atomicity for anything after that call.
+This predates issue #523 (found in `_rebuild_schema_transactional()`, which dates to an
+earlier extraction).
+
+A second, easy-to-miss consequence: if the executed script itself contains `PRAGMA`
+statements (e.g. a `CREATE TABLE`/`CREATE TRIGGER` schema script that leads with
+`PRAGMA foreign_keys = ON;` for standalone use), those PRAGMAs also run — silently
+overriding any connection-level setting the caller had explicitly configured moments
+earlier (e.g. `PRAGMA foreign_keys = OFF;` set specifically to suppress FK enforcement
+during a table-rename-based migration, per Gotcha 3's pattern). Combined with SQLite's
+foreign-key-definition auto-repoint-on-rename behavior, this produced a third, distinct,
+silent-data-loss failure mode: `DROP TABLE` on a renamed parent table (with FK
+enforcement now unexpectedly back on) cascade-deleted not-yet-migrated rows in a child
+table whose FK definition had auto-repointed to follow the same rename — with **no
+exception raised at all**, only discovered via a non-empty-data regression test.
+
+**Mitigation:** never call `executescript()` inside a manually-managed transaction whose
+atomicity actually matters. Split the script into individual statements (Python's
+`sqlite3.complete_statement()` correctly handles multi-statement blocks like
+`CREATE TRIGGER ... BEGIN ... END;` that have embedded semicolons) and `execute()` them
+one at a time inside the transaction — explicitly filtering out any `PRAGMA` statements
+from the script if the transaction depends on a specific PRAGMA state the caller already
+established, since those must not be allowed to silently override it mid-transaction.
 
 ## When this applies
 


### PR DESCRIPTION
## Summary
- Resolves the "documented separately" pointer left in the #523 wiki entry (`wiki/decisions/sqlite-trigger-enforcement-gotchas.md`) now that #552 has landed (#557).
- Adds Gotcha 4: `conn.executescript()`'s implicit-commit behavior, plus the less-obvious consequence found during #552's implementation — a script's own embedded `PRAGMA` statements can silently override a caller's connection-level PRAGMA setting mid-transaction, which combined with SQLite's FK-auto-repoint-on-rename behavior produced a third, silent-data-loss failure mode only found via a non-empty-data regression test.

## Test plan
- [x] Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)