### PR TITLE
chore: sync skills-lock.json for agent-agentic-os reinstall (issue #552)

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -258,7 +258,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-09-05T13:55:24.862366Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "dependency-management": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -314,7 +314,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "executing-plans": {
       "source": "https://github.com/obra/superpowers",
@@ -440,7 +440,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-09-05T13:44:55.035347Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "issue-pr-lifecycle-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -454,7 +454,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-09-06T21:33:53.022569Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "issue-worktree-agent": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -608,7 +608,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "optimize-context": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -629,112 +629,112 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-clean-locks": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-environment-probe": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-eval-backport": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-eval-lab-setup": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-eval-runner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-evolution-planner": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-evolution-verifier": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-experiment-log": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-guide": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-health-check": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-09-06T21:33:53.022569Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-improvement-loop": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-improvement-report": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-init": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-memory-manager": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "os-skill-improvement": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "path-reference-auditor": {
       "source": "https://github.com/richfrem/agent-plugins-skills",
@@ -797,7 +797,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-09-06T21:33:53.022569Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "requesting-code-review": {
       "source": "https://github.com/obra/superpowers",
@@ -867,7 +867,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "subagent-driven-development": {
       "source": "https://github.com/obra/superpowers",
@@ -923,7 +923,7 @@
       "sourceType": "local",
       "computedHash": "",
       "installedAt": "2026-08-31T14:38:07.375378Z",
-      "updatedAt": "2026-09-07T17:08:18.383777Z"
+      "updatedAt": "2026-09-07T18:07:39.201236Z"
     },
     "triple-loop-learning": {
       "source": "https://github.com/richfrem/agent-plugins-skills",


### PR DESCRIPTION
## Summary
- Regenerates `skills-lock.json` timestamps after reinstalling `agent-agentic-os` via `plugin_add.py`.
- Syncs `.agents/skills/interview-spec/scripts/control_plane/adapters.py` with the #552 atomicity fix (already merged into `main` via #557/#558) — confirmed the deployed copy contains `_split_schema_sql_statements()` and `_check_no_orphaned_migration_tables()`.

## Test plan
- [x] Lockfile-only change, machine-generated. No code touched — `adapters.py` itself is unchanged in this PR (already merged in #557).

🤖 Generated with [Claude Code](https://claude.com/claude-code)