### PR TITLE
chore: gitignore docs/plans/ and docs/superpowers/ (local planning/spec output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ context/memory.md
 context/os-state.json
 context/status.md
 
+# Local planning/spec working docs (interview-spec, brainstorming, writing-plans output) —
+# not durable repo documentation; already-tracked files here predate this ignore rule and
+# stay tracked (gitignore doesn't retroactively untrack committed files).
+docs/plans/
+docs/superpowers/
+


### PR DESCRIPTION
## Summary
- Gitignores `docs/plans/` and `docs/superpowers/` — these hold interview-spec/brainstorming/writing-plans working docs, not durable repo documentation.
- Already-tracked files predating this rule stay tracked — gitignore doesn't retroactively untrack committed files, only future untracked ones (verified: `docs/plans/issue-552-spec.md` and `docs/superpowers/plans/2026-05-30-hardened-control-plane.md` remain tracked; a new test file under `docs/plans/` was confirmed ignored).

## Test plan
- [x] `git check-ignore -v` confirms new files under both directories are ignored.
- [x] `git ls-files` confirms existing tracked files under both directories remain tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)