### PR TITLE
fix(agent-scaffolders): repair example skill frontmatter link

### DIFF
--- a/.agent/map-debt.md
+++ b/.agent/map-debt.md
@@ -53,6 +53,22 @@ Do not delete resolved items; set `Status: RESOLVED` to maintain history.
 
 ---
 
+## 2026-09-07 — create-command Example Frontmatter
+
+- **Artifact:** `plugins/agent-scaffolders/references/examples/SKILL.md`
+  **Friction:** The example was a plain-text broken symlink target (`../../../create-stateful-skill/SKILL.md`) rather than a resolvable link, so the installer copied that text into `.agents/` and the skill loader reported missing YAML frontmatter.
+  **Why not deferred:** Small, in-bounds symlink repair.
+  **Fix:** Registered the example source with `symlink_manager.py` to point at the canonical `create-stateful-skill/SKILL.md`, restored the manifest links, and reinstalled the plugin.
+  **Evidence:** Pre-fix frontmatter contract failed on the literal path text; post-fix source and installed files begin with `---`.
+  **Severity:** S | **Repeat:** NO | **Status:** RESOLVED
+
+- **Artifact:** `plugins/plugin-manager/scripts/plugin_add.py` runtime reinstall
+  **Friction:** Initial reinstall was blocked by sandbox permissions while rewriting `.agents/` ownership and installed symlink artifacts.
+  **Why not deferred:** Required runtime synchronization could not be verified until rerun with filesystem approval.
+  **Fix:** Reran the same reinstall with approved filesystem access.
+  **Evidence:** Initial run exited 1 with `Operation not permitted`; approved rerun completed successfully.
+  **Severity:** S | **Repeat:** NO | **Status:** RESOLVED
+
 ## 2026-08-24 — Marketplace Manifest Schema & Scaffolding/Auditing Hardening
 
 - **Artifact:** `plugins/agent-scaffolders/skills/create-plugin/SKILL.md`, `scaffold.py`, `manage-marketplace/SKILL.md`, `audit.py`, `audit-plugin/SKILL.md`, `audit-plugin-l5/SKILL.md`, `l5-red-team-auditor/SKILL.md`, `plugins/plugin-manager/scripts/plugin_add.py`

--- a/.agent/map-debt.md
+++ b/.agent/map-debt.md
@@ -55,9 +55,11 @@ Do not delete resolved items; set `Status: RESOLVED` to maintain history.
 
 ## 2026-09-07 — create-command Example Frontmatter
 
+- **Cycle/Session ID:** `20260907-create-command-frontmatter`
 - **Artifact:** `plugins/agent-scaffolders/references/examples/SKILL.md`
   **Friction:** The example was a plain-text broken symlink target (`../../../create-stateful-skill/SKILL.md`) rather than a resolvable link, so the installer copied that text into `.agents/` and the skill loader reported missing YAML frontmatter.
   **Why not deferred:** Small, in-bounds symlink repair.
+  **Recommended fix:** Keep reference examples that reuse skill documents registered through `symlink_manager.py` and validate installed `SKILL.md` frontmatter.
   **Fix:** Registered the example source with `symlink_manager.py` to point at the canonical `create-stateful-skill/SKILL.md`, restored the manifest links, and reinstalled the plugin.
   **Evidence:** Pre-fix frontmatter contract failed on the literal path text; post-fix source and installed files begin with `---`.
   **Severity:** S | **Repeat:** NO | **Status:** RESOLVED
@@ -65,6 +67,7 @@ Do not delete resolved items; set `Status: RESOLVED` to maintain history.
 - **Artifact:** `plugins/plugin-manager/scripts/plugin_add.py` runtime reinstall
   **Friction:** Initial reinstall was blocked by sandbox permissions while rewriting `.agents/` ownership and installed symlink artifacts.
   **Why not deferred:** Required runtime synchronization could not be verified until rerun with filesystem approval.
+  **Recommended fix:** Rerun the required installer with filesystem access when the sandbox blocks `.agents/` writes.
   **Fix:** Reran the same reinstall with approved filesystem access.
   **Evidence:** Initial run exited 1 with `Operation not permitted`; approved rerun completed successfully.
   **Severity:** S | **Repeat:** NO | **Status:** RESOLVED

--- a/plugins/agent-scaffolders/references/evolution-log.md
+++ b/plugins/agent-scaffolders/references/evolution-log.md
@@ -2,3 +2,4 @@
 
 | Date | Tier | Friction / Failure | Patch | Edit Type | Outcome |
 |------|------|-------------------|-------|-----------|---------|
+| 2026-09-07 | Tier 2 | `references/examples/SKILL.md` was installed as a literal broken symlink target and failed frontmatter loading | Registered the canonical `create-stateful-skill/SKILL.md` source via `symlink_manager.py`, restored links, and reinstalled | Symlink repair | Resolved; source and installed example now carry valid YAML frontmatter |

--- a/plugins/agent-scaffolders/references/examples/SKILL.md
+++ b/plugins/agent-scaffolders/references/examples/SKILL.md
@@ -1,1 +1,1 @@
-../../../create-stateful-skill/SKILL.md
+../../skills/create-stateful-skill/SKILL.md

--- a/plugins/plugin-manager/references/evolution-log.md
+++ b/plugins/plugin-manager/references/evolution-log.md
@@ -35,3 +35,4 @@
 | 2026-08-23 | Tier 1 | Failure: Duplicate top-level key 'name' in plugin.json of exploration-cycle-plugin | None | None | FAILED |
 | 2026-08-23 | Tier 1 | Failure: Duplicate top-level key 'name' in plugin.json of obsidian-wiki-engine | None | None | FAILED |
 | 2026-08-23 | Tier 1 | Failure: Duplicate top-level key 'name' in plugin.json of plugin-manager | None | None | FAILED |
+| 2026-09-07 | Tier 2 | Failure: Installation crash for agent-scaffolders: [Errno 1] Operation not permitted: '/Users/richardfremmerlid/Projects/agent-plugins-skills/.agents/ownership/agent-scaffolders.json': PermissionError: [Errno 1] Operation not permitted: '/Users/richardfremmerlid/Projects/agent-plugins-skills/.agents/ownership/agent-scaffolders.json' | None | None | FAILED |

--- a/symlinks.json
+++ b/symlinks.json
@@ -10752,6 +10752,12 @@
       "dst": "plugins/agent-agentic-os/skills/interview-spec/references/control-plane-pipeline.mermaid",
       "strategy": "symlink",
       "description": "Control-plane diagram referenced by interview-spec pipeline docs"
+    },
+    {
+      "src": "plugins/agent-scaffolders/skills/create-stateful-skill/SKILL.md",
+      "dst": "plugins/agent-scaffolders/references/examples/SKILL.md",
+      "strategy": "symlink",
+      "description": "Example skill document used by create-command documentation"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Repair the `create-command` example `SKILL.md` source link through the symlink manifest.
- Reinstall `agent-scaffolders` so the runtime copy contains valid YAML frontmatter.
- Record the resolved loader issue and reinstall friction in the evolution records.

## Verification
- Source, spoke, and `.agents/` copies all pass the YAML frontmatter contract.
- `audit.py --path plugins/agent-scaffolders`: 0 errors.
- `audit_plugin_structure.py plugins/agent-scaffolders`: 0 errors, 1 pre-existing warning.
- `symlink_manager.py audit` and `diagnose`: all links OK.
- Local plugin reinstall: successful, 32 skills installed.

## Notes
- Pre-existing/generated local changes to `skills-lock.json` and `plugins/plugin-manager/references/evolution-log.md` remain unstaged and are not part of this PR.